### PR TITLE
Added line_normal method

### DIFF
--- a/src/ImageDraw.jl
+++ b/src/ImageDraw.jl
@@ -14,6 +14,8 @@ export
 	line,
 	bresenham,
 	xiaolin_wu,
+	line_normal!,
+	line_normal,
 
 	#Ellipse
 	ellipse!,

--- a/src/ImageDraw.jl
+++ b/src/ImageDraw.jl
@@ -8,14 +8,16 @@ include("ellipse2d.jl")
 include("circle2d.jl")
 include("paths.jl")
 
+#export Types
+export LineTwoPoints, LineNormal
+
+#export Methods
 export
 	#Lines
 	line!,
 	line,
 	bresenham,
 	xiaolin_wu,
-	line_normal!,
-	line_normal,
 
 	#Ellipse
 	ellipse!,

--- a/src/line2d.jl
+++ b/src/line2d.jl
@@ -1,25 +1,84 @@
+abstract Line
+
+immutable LineTwoPoints <: Line
+    y0::Number
+    x0::Number
+    y1::Number
+    x1::Number
+end
+
+LineTwoPoints(p1::CartesianIndex{2}, p2::CartesianIndex{2}) = LineTwoPoints(p1[1],p1[2],p2[1],p2[2])
+
+immutable LineNormal <: Line
+    ρ::Number
+    θ::Number
+end
+
+LineNormal(τ::Tuple{Number,Number}) = LineNormal(τ...)
+
 """
 ```
-img_with_line = line(img, p1, p2, color, method)
-img_with_line = line(img, y0, x0, y1, x1, color, method)
+img_with_line = line(img, l, color, method)
+img_with_line = line(img, LineTwoPoints(p1, p2), color, method)
+img_with_line = line(img, LineTwoPoints(y0, x0, y1, x1), color, method)
+img_with_line = line(img, LineNormal(ρ,θ), color, method)
 ```
 
-Draws a line on the input image given the points p1, p2 as CartesianIndex{2} with the
-given `color`. Lines are drawn using the `bresenham` method by default. If anti-aliasing
-is required, the `xiaolin_wu` can be used.
+Draws a line on the input image.
+img     =   Image to draw lines on
+l       =   A `Line` type object describing the line to be drawn.
+            A line can be represented in "two-points form" using `LineTwoPoints(p1,p2)`
+            where points p1, p2 are `CartesianIndex{2}`.
+            It can also be represented in "two-points form" using `LineTwoPoints(y0,x0,y1,x1)`
+            A line can also be represented in "normal form" using `LineNormal(ρ,θ)`
+            where ρ = perpendicular distance of line and θ is angle from x-axis in radians.
+color   =   Color of the line to be drawn
+method  =   Lines are drawn using the `bresenham` method by default. If anti-aliasing
+            is required, the `xiaolin_wu` can be used.
+
 """
+
+#methods for LineTwoPoints parametrization
+
 line{T<:Colorant}(img::AbstractArray{T, 2}, args...) = line!(copy(img), args...)
 
-function line!{T<:Colorant}(img::AbstractArray{T, 2}, p1::CartesianIndex{2}, p2::CartesianIndex{2}, method::Function = bresenham)
-    line!(img, p1[1], p1[2], p2[1], p2[2], one(T), method)
-end
+line!{T<:Colorant}(img::AbstractArray{T, 2}, p1::CartesianIndex{2}, p2::CartesianIndex{2}, method::Function = bresenham) =
+    line!(img, LineTwoPoints(p1, p2), one(T), method)
 
-function line!{T<:Colorant}(img::AbstractArray{T, 2}, p1::CartesianIndex{2}, p2::CartesianIndex{2}, color::T, method::Function = bresenham)
-    line!(img, p1[1], p1[2], p2[1], p2[2], color, method)
-end
+line!{T<:Colorant}(img::AbstractArray{T, 2}, p1::CartesianIndex{2}, p2::CartesianIndex{2}, color::T, method::Function = bresenham) =
+    line!(img, LineTwoPoints(p1, p2), color, method)
 
 line!{T<:Colorant}(img::AbstractArray{T, 2}, y0::Int, x0::Int, y1::Int, x1::Int, method::Function = bresenham) = line!(img, y0, x0, y1, x1, one(T), method)
 line!{T<:Colorant}(img::AbstractArray{T, 2}, y0::Int, x0::Int, y1::Int, x1::Int, color::T, method::Function = bresenham) = method(img, y0, x0, y1, x1, color)
+
+line!{T<:Colorant}(img::AbstractArray{T, 2}, l::LineTwoPoints, method::Function = bresenham) = line!(img, l, one(T), method)
+line!{T<:Colorant}(img::AbstractArray{T, 2}, l::LineTwoPoints, color::T, method::Function = bresenham) = method(img, l.y0, l.x0, l.y1, l.x1, color)
+
+# methods for LineNormal parametrization
+
+line!{T<:Colorant}(img::AbstractArray{T, 2}, l::LineNormal, method::Function = bresenham) = 
+    line!(img, l, one(T), method)
+
+function line!{T<:Colorant}(img::AbstractArray{T, 2}, l::LineNormal, color::T, method::Function = bresenham)
+    indsy, indsx = indices(img)
+    cosθ = cos(l.θ)
+    sinθ = sin(l.θ)
+    intersections_x = [(x, (l.ρ - x*cosθ)/sinθ) for x in (first(indsx), last(indsx))]
+    intersections_y = [((l.ρ - y*sinθ)/cosθ, y) for y in (first(indsy), last(indsy))]
+    valid_intersections = Vector{Tuple{Number,Number}}(0)
+    for intersection in vcat(intersections_x, intersections_y)
+        if 1 <= intersection[1] <= indsx.stop && 1 <= intersection[2] <= indsy.stop
+            push!(valid_intersections,intersection)
+        end
+    end
+    if length(valid_intersections) > 0
+        method(img, round(Int,valid_intersections[1][2]), round(Int,valid_intersections[1][1]), round(Int,valid_intersections[2][2]), round(Int,valid_intersections[2][1]), color)
+    else
+        img
+    end
+end
+
+
 
 function bresenham{T<:Colorant}(img::AbstractArray{T, 2}, y0::Int, x0::Int, y1::Int, x1::Int, color::T)
     dx = abs(x1 - x0)
@@ -103,51 +162,4 @@ function xiaolin_wu{T<:Gray}(img::AbstractArray{T, 2}, y0::Int, x0::Int, y1::Int
         intery += gradient
     end
     img
-end
-
-"""
-```
-img_with_line = line_normal(img, τ, color, method)
-img_with_line = line_normal(img, ρ, θ, color, method)
-```
-
-Draws a line on the input image given tuple `τ` of the form (ρ,θ) for the normal form of line:
-    x*cos(θ) + y*sin(θ) = ρ
-with the given `color`. Lines are drawn using the `bresenham` method by default. If anti-aliasing
-is required, the `xiaolin_wu` can be used.
-"""
-line_normal{T<:Colorant}(img::AbstractArray{T, 2}, args...) = line_normal!(copy(img), args...)
-
-line_normal!{T<:Colorant}(img::AbstractArray{T, 2}, τ::Tuple{Number,Number}, method::Function = bresenham) = 
-    line_normal!(img, τ[1], τ[2], one(T), method)
-
-line_normal!{T<:Colorant}(img::AbstractArray{T, 2}, τ::Tuple{Number,Number}, color::T, method::Function = bresenham) = 
-    line_normal!(img, τ[1], τ[2], color, method)
-
-line_normal!{T<:Colorant}(img::AbstractArray{T, 2}, ρ::Number, θ::Number, method::Function = bresenham) =
-    line_normal!(img, ρ, θ, one(T), method)
-
-function line_normal!{T<:Colorant}(img::AbstractArray{T, 2}, ρ::Number, θ::Number, color::T, method::Function = bresenham)
-    h,w = size(img)
-    ρ -= 1; h -= 1; w -= 1
-    t = Vector{Number}(4)
-    cosθ = cos(θ)
-    sinθ = sin(θ)
-    t[1] = ( ρ * cosθ    )/ sinθ
-    t[2] = (-ρ * sinθ    )/ cosθ
-    t[3] = ( ρ * cosθ - w)/ sinθ
-    t[4] = (-ρ * sinθ + h)/ cosθ
-    hasInf = false
-    for i in 1:4
-        if ! isfinite(t[i])
-            if ! hasInf
-                t[i] = Inf
-                hasInf = true
-            else
-                t[i] = -Inf
-            end
-        end
-    end
-    sort!(t)
-    method(img, round(Integer, ρ*sinθ + t[2]*cosθ + 1), round(Integer, ρ*cosθ - t[2]*sinθ + 1), round(Integer, ρ*sinθ + t[3]*cosθ + 1), round(Integer, ρ*cosθ - t[3]*sinθ + 1), color)
 end

--- a/test/line2d.jl
+++ b/test/line2d.jl
@@ -150,4 +150,35 @@
 		@test expected == res
 	end
 
+	@testset "line_normal" begin
+		img = zeros(Gray, 10, 10)
+		expected = copy(img)
+		expected[1:10, 1] = 1
+		line_normal!(img, 1, 0)
+		@test img == expected
+		fill!(img,zero(Gray))
+		@test line_normal(img, 1, 0) == expected
+		expected[1:10, 1] = Gray(0.5)
+		@test line_normal(img, 1, 0, Gray(0.5)) == expected
+		fill!(expected,zero(Gray))
+		expected[1:10,2] = expected[1:10,7] = expected[10,1:10] = Gray(0.3)
+		line_normal!(img, 2, 0, Gray(0.3))
+		line_normal!(img, 7, 0, Gray(0.3))
+		line_normal!(img, 10, π/2, Gray(0.3))
+		@test img == expected
+		fill!(img,zero(Gray))
+		fill!(expected,zero(Gray))
+		for i in 1:10
+			expected[i,10-i+1] = 1
+		end
+		@test line_normal(img, 7.5, π/4) == expected
+		for i in 1:10
+			expected[i,10-i+1] = 0.8
+		end
+		fill!(expected, Gray(0))
+		for i in 1:10
+			expected[i,i] = Gray(0.8)
+		end
+		@test line_normal(img,(1,-π/4), Gray(0.8)) == expected
+	end
 end

--- a/test/line2d.jl
+++ b/test/line2d.jl
@@ -150,28 +150,28 @@
 		@test expected == res
 	end
 
-	@testset "line_normal" begin
+	@testset "LineNormal" begin
 		img = zeros(Gray, 10, 10)
 		expected = copy(img)
 		expected[1:10, 1] = 1
-		line_normal!(img, 1, 0)
+		line!(img, LineNormal(1, 0))
 		@test img == expected
 		fill!(img,zero(Gray))
-		@test line_normal(img, 1, 0) == expected
+		@test line(img, LineNormal(1, 0)) == expected
 		expected[1:10, 1] = Gray(0.5)
-		@test line_normal(img, 1, 0, Gray(0.5)) == expected
+		@test line(img, LineNormal(1, 0), Gray(0.5)) == expected
 		fill!(expected,zero(Gray))
 		expected[1:10,2] = expected[1:10,7] = expected[10,1:10] = Gray(0.3)
-		line_normal!(img, 2, 0, Gray(0.3))
-		line_normal!(img, 7, 0, Gray(0.3))
-		line_normal!(img, 10, π/2, Gray(0.3))
+		line!(img, LineNormal(2, 0), Gray(0.3))
+		line!(img, LineNormal(7, 0), Gray(0.3))
+		line!(img, LineNormal(10, π/2), Gray(0.3))
 		@test img == expected
 		fill!(img,zero(Gray))
 		fill!(expected,zero(Gray))
 		for i in 1:10
 			expected[i,10-i+1] = 1
 		end
-		@test line_normal(img, 7.5, π/4) == expected
+		@test line(img, LineNormal(7.5, π/4)) == expected
 		for i in 1:10
 			expected[i,10-i+1] = 0.8
 		end
@@ -179,6 +179,11 @@
 		for i in 1:10
 			expected[i,i] = Gray(0.8)
 		end
-		@test line_normal(img,(1,-π/4), Gray(0.8)) == expected
+		@test line(img, LineNormal((0,-π/4)), Gray(0.8)) == expected
+		img = zeros(Gray,3,3)
+		expected = copy(img)
+		@test line(img, LineNormal(4,0)) == expected
+		@test line(img, LineNormal(4,π/2)) == expected
+		@test line(img, LineNormal(5,π/4)) == expected
 	end
 end


### PR DESCRIPTION
Draws a line on image, given tuple τ of the form of (ρ,θ) for the normal form of line:
    x*cos(θ) + y*sin(θ) = ρ

Works nicely with `hough_transform_standard`:
Original image:
![org](https://cloud.githubusercontent.com/assets/15063205/24171584/2257f80e-0eab-11e7-82f4-9cd8038453d8.png)

After applying `canny`:
![canny](https://cloud.githubusercontent.com/assets/15063205/24171581/21d35068-0eab-11e7-9847-bd4293edd541.png)

Applied `hough_transform_standard` and then using `line_normal`:
![ht](https://cloud.githubusercontent.com/assets/15063205/24171582/2204b018-0eab-11e7-9850-ce8c195b2266.png)
