### PR TITLE
Modified structure of ImageDraw.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.5
 ColorTypes 0.3.2
 ImageCore 0.1.1
-Distances
+Distances 0.1.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.5
 ColorTypes 0.3.2
 ImageCore 0.1.1
 Distances 0.1.0
+Compat 0.17.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.5
 ColorTypes 0.3.2
 ImageCore 0.1.1
+Distances

--- a/src/ImageDraw.jl
+++ b/src/ImageDraw.jl
@@ -1,7 +1,7 @@
 module ImageDraw
 
 # package code goes here
-using ImageCore, ColorTypes, Distances
+using ImageCore, ColorTypes, Distances, Compat
 
 include("core.jl")
 include("line2d.jl")

--- a/src/ImageDraw.jl
+++ b/src/ImageDraw.jl
@@ -1,34 +1,48 @@
 module ImageDraw
 
 # package code goes here
-using ImageCore, ColorTypes
+using ImageCore, ColorTypes, Distances
 
+include("core.jl")
 include("line2d.jl")
 include("ellipse2d.jl")
 include("circle2d.jl")
 include("paths.jl")
 
-#export Types
-export LineTwoPoints, LineNormal
-
-#export Methods
+#export methods
 export
-	#Lines
-	line!,
-	line,
+	draw,
+	draw!,
 	bresenham,
-	xiaolin_wu,
+	xiaolin_wu
+
+#export types
+export
+	#Drawable
+	Drawable,
+
+	#Point
+	Point,
+
+	#Lines
+	LineNormal,
+	LineTwoPoints,
+
+	#LineSegment
+	LineSegment,
 
 	#Ellipse
-	ellipse!,
-	ellipse,
+	Ellipse,
 
-	#Circle
-	circle!,
-	circle,
+	#Circles
+	CirclePointRadius,
+	CircleThreePoints,
 
-	#Paths
-	path!,
-	path
+	#Path
+	Path,
+
+	#Polygons
+	Polygon,
+	RegularPolygon
 
 end # module

--- a/src/circle2d.jl
+++ b/src/circle2d.jl
@@ -18,10 +18,10 @@ function draw!{T<:Colorant}(img::AbstractArray{T, 2}, circle::CircleThreePoints,
     x2 = circle.p2.x; y2 = circle.p2.y
     x3 = circle.p3.x; y3 = circle.p3.y
     D = det([[x1, x2, x3] [y1, y2, y3] [1, 1, 1]])
-    ! isapprox(D, 0, rtol = 0, atol = eps(Float64)) || error("Points do not lie on unique circle")
+    ! isapprox(D, 0, rtol = 0, atol = maximum(abs, (x1, x2, x3)) * maximum(abs, (y1, y2, y3)) * eps(Float64)) || error("Points do not lie on unique circle")
     R = [[y2 - y3, x3 - x2] [y2 - y1, x1 - x2]] * [(x1^2 + y1^2)-(x2^2 + y2^2), (x2^2 + y2^2)-(x3^2 + y3^2)] / (2 * D)
     ρ = euclidean([x1, y1], R)
     (first(ind[2]) <= R[1] <= last(ind[2]) && first(ind[1]) <= R[2] <= last(ind[1])) || error("Center of circle is out of the bounds of image")
-    ρ - 1 <= minabs([R[1] - first(ind[2]), R[1] - last(ind[2]), R[2] - first(ind[1]), R[2] - last(ind[1])]) || error("Circle is out of the bounds of image : Radius is too large")
+    ρ - 1 <= minimum(abs, [R[1] - first(ind[2]), R[1] - last(ind[2]), R[2] - first(ind[1]), R[2] - last(ind[1])]) || error("Circle is out of the bounds of image : Radius is too large")
     draw!(img, CirclePointRadius(Point(round(Int,R[1]), round(Int,R[2])), ρ), color)
 end

--- a/src/circle2d.jl
+++ b/src/circle2d.jl
@@ -1,15 +1,24 @@
-"""
-```
-img_with_circle = circle(img, center, radiusy, radiusx)
-img_with_circle = circle(img, center, color, radiusy, radiusx)
-img_with_circle = circle(img, y, x, radiusy, radiusx)
-img_with_circle = circle(img, y, x, color, radiusy, radiusx)
-```
-Draws a circle on the input image given the `center` as a `CartesianIndex{2}` or
-as coordinates `(y, x)` using the specified `color`. If `color` is not specified,
-`one(eltype(img))` is used.
-"""
-circle{T<:Colorant}(img::AbstractArray{T, 2}, args...) = circle!(copy(img), args...)
-circle!{T<:Colorant}(img::AbstractArray{T, 2}, center::CartesianIndex{2}, color::T, radius::Real) = circle!(img, center[1], center[2], color, radius)
-circle!{T<:Colorant}(img::AbstractArray{T, 2}, y::Int, x::Int, radius::Real) = circle!(img, y, x, one(T), radius)
-circle!{T<:Colorant}(img::AbstractArray{T, 2}, y::Int, x::Int, color::T, radius::Real) = ellipse!(img, y, x, color, radius, radius)
+#CirclePointRadius methods
+
+CirclePointRadius(x::Int, y::Int, ρ::Real) = CirclePointRadius(Point(x,y), ρ)
+CirclePointRadius(p::CartesianIndex{2}, ρ::Real) = CirclePointRadius(Point(p), ρ)
+
+draw!{T<:Colorant}(img::AbstractArray{T, 2}, circle::CirclePointRadius, color::T) = draw!(img, Ellipse(circle), color)
+
+#CircleThreePoints methods
+
+CircleThreePoints(x1::Int, y1::Int, x2::Int, y2::Int, x3::Int, y3::Int) =
+    CircleThreePoints(Point(x1,y1), Point(x2,y2), Point(x3,y3))
+CircleThreePoints(p1::CartesianIndex{2}, p2::CartesianIndex{2}, p3::CartesianIndex{2}) =
+    CircleThreePoints(Point(p1), Point(p2), Point(p3))
+
+function draw!{T<:Colorant}(img::AbstractArray{T, 2}, circle::CircleThreePoints, color::T)
+    x1 = circle.p1.x; y1 = circle.p1.y
+    x2 = circle.p2.x; y2 = circle.p2.y
+    x3 = circle.p3.x; y3 = circle.p3.y
+    D = det([[x1, x2, x3] [y1, y2, y3] [1, 1, 1]])
+    D != 0 || error("Points do not lie on unique circle")
+    R = [[y2 - y3, x3 - x2] [y2 - y1, x1 - x2]] * [(x1^2 + y1^2)-(x2^2 + y2^2), (x2^2 + y2^2)-(x3^2 + y3^2)] / (2 * D)
+    ρ = euclidean([x1, y1], R)
+    draw!(img, CirclePointRadius(Point(R[1], R[2]), ρ), color)
+end

--- a/src/circle2d.jl
+++ b/src/circle2d.jl
@@ -13,12 +13,15 @@ CircleThreePoints(p1::CartesianIndex{2}, p2::CartesianIndex{2}, p3::CartesianInd
     CircleThreePoints(Point(p1), Point(p2), Point(p3))
 
 function draw!{T<:Colorant}(img::AbstractArray{T, 2}, circle::CircleThreePoints, color::T)
+    ind = indices(img)
     x1 = circle.p1.x; y1 = circle.p1.y
     x2 = circle.p2.x; y2 = circle.p2.y
     x3 = circle.p3.x; y3 = circle.p3.y
     D = det([[x1, x2, x3] [y1, y2, y3] [1, 1, 1]])
-    D != 0 || error("Points do not lie on unique circle")
+    ! isapprox(D, 0, rtol = 0, atol = eps(Float64)) || error("Points do not lie on unique circle")
     R = [[y2 - y3, x3 - x2] [y2 - y1, x1 - x2]] * [(x1^2 + y1^2)-(x2^2 + y2^2), (x2^2 + y2^2)-(x3^2 + y3^2)] / (2 * D)
     ρ = euclidean([x1, y1], R)
+    (first(ind[2]) <= R[1] <= last(ind[2]) && first(ind[1]) <= R[2] <= last(ind[1])) || error("Center of circle is out of the bounds of image")
+    ρ - 1 <= minabs([R[1] - first(ind[2]), R[1] - last(ind[2]), R[2] - first(ind[1]), R[2] - last(ind[1])]) || error("Circle is out of the bounds of image : Radius is too large")
     draw!(img, CirclePointRadius(Point(round(Int,R[1]), round(Int,R[2])), ρ), color)
 end

--- a/src/circle2d.jl
+++ b/src/circle2d.jl
@@ -20,5 +20,5 @@ function draw!{T<:Colorant}(img::AbstractArray{T, 2}, circle::CircleThreePoints,
     D != 0 || error("Points do not lie on unique circle")
     R = [[y2 - y3, x3 - x2] [y2 - y1, x1 - x2]] * [(x1^2 + y1^2)-(x2^2 + y2^2), (x2^2 + y2^2)-(x3^2 + y3^2)] / (2 * D)
     ρ = euclidean([x1, y1], R)
-    draw!(img, CirclePointRadius(Point(R[1], R[2]), ρ), color)
+    draw!(img, CirclePointRadius(Point(round(Int,R[1]), round(Int,R[2])), ρ), color)
 end

--- a/src/circle2d.jl
+++ b/src/circle2d.jl
@@ -1,7 +1,7 @@
 #CirclePointRadius methods
 
-CirclePointRadius(x::Int, y::Int, ρ::Real) = CirclePointRadius(Point(x,y), ρ)
-CirclePointRadius(p::CartesianIndex{2}, ρ::Real) = CirclePointRadius(Point(p), ρ)
+CirclePointRadius{T<:Real}(x::Int, y::Int, ρ::T) = CirclePointRadius(Point(x,y), ρ)
+CirclePointRadius{T<:Real}(p::CartesianIndex{2}, ρ::T) = CirclePointRadius(Point(p), ρ)
 
 draw!{T<:Colorant}(img::AbstractArray{T, 2}, circle::CirclePointRadius, color::T) = draw!(img, Ellipse(circle), color)
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,0 +1,170 @@
+"""
+Type representing any object drawable on image
+"""
+abstract Drawable
+
+"""
+    p = Point(x,y)
+    p = Point(c)
+
+A `Drawable` point on the image
+"""
+immutable Point <: Drawable
+    x::Int
+    y::Int
+end
+
+abstract Line <: Drawable
+abstract Circle <: Drawable
+
+
+"""
+    line = LineTwoPoints(p1, p2)
+
+A `Drawable` infinite length line passing through the two points
+`p1` and `p2`.
+"""
+immutable LineTwoPoints <: Line
+    p1::Point
+    p2::Point
+end
+
+"""
+    line = LineNormal(ρ, θ)
+
+A `Drawable` infinte length line having perpendicular length `ρ` from
+origin and angle `θ` between the perpendicular and x-axis
+"""
+immutable LineNormal <: Line
+    ρ::Real
+    θ::Real
+end
+
+"""
+    circle = CircleThreePoints(p1, p2, p3)
+
+A `Drawable` circle passing through points `p1`, `p2` and `p3`
+"""
+immutable CircleThreePoints <: Circle
+    p1::Point
+    p2::Point
+    p3::Point
+end
+
+"""
+    circle = CirclePointRadius(p, ρ)
+
+A `Drawable` circle having center `p` and radius `ρ`
+"""
+immutable CirclePointRadius <: Circle
+    center::Point
+    ρ::Real
+end
+
+"""
+    ls = LineSegment(p1, p2)
+
+A `Drawable` finite length line between `p1` and `p2`
+"""
+immutable LineSegment <: Drawable
+    p1::Point
+    p2::Point
+end
+
+"""
+    path = Path([point])
+
+A `Drawable` sequence of line segments
+"""
+immutable Path <: Drawable
+    vertices::Vector{Point}
+end
+
+"""
+    ellipse = Ellipse(center, ρx, ρy)
+
+A `Drawable` ellipse with center `center` and parameters `ρx` and `ρy`
+"""
+immutable Ellipse <: Drawable
+    center::Point
+    ρx::Real
+    ρy::Real
+end
+
+"""
+    polygon = Polygon([vertex])
+
+A `Drawable` polygon represented by a `Vector` of vertices
+"""
+immutable Polygon <: Drawable
+    vertices::Vector{Point}
+end
+
+"""
+    rp = RegularPolygon(center, side_count, side_length, θ)
+
+A `Drawable` regular polygon.
+
+#Arguments
+* `center::Point` : the center of the polygon
+* `side_count::Int` : number of sides of the polygon
+* `side_length::Real` : length of each side
+* `θ::Real` : orientation of the polygon w.r.t x-axis
+"""
+immutable RegularPolygon <: Drawable
+    center::Point
+    side_count::Int
+    side_length::Real
+    θ::Real
+end
+
+"""
+    img = draw!(img, drawable, color)
+    img = draw!(img, drawable)
+
+Draws `drawable` on `img` using color `color` which
+defaults to `one(eltype(img))`
+"""
+draw!{T<:Colorant}(img::AbstractArray{T,2}, object::Drawable) = draw!(img, object, one(T))
+
+
+"""
+    img = draw!(img, [drawable], [color])
+    img = draw!(img, [drawable] ,color)
+    img = draw!(img, [drawable])
+
+Draws all objects in `[drawable]` in the given order on `img` using
+corresponding colors from `[color]` which defaults to `one(eltype(img))`
+"""
+function draw!{T<:Colorant, U<:Drawable, V<:Colorant}(img::AbstractArray{T,2}, objects::Vector{U}, colors::Vector{V})
+    colors = copy(colors)
+    while length(colors) < length(objects)
+        push!(colors, one(T))
+    end
+    map(objects, colors) do object, color
+        draw!(img, object, color)
+    end
+    img
+end
+
+draw!{T<:Colorant, U<:Drawable}(img::AbstractArray{T,2}, objects::Vector{U}, color::T = one(T)) =
+    draw!(img, objects, [color])
+
+"""
+    img_new = draw(img, drawable, color)
+    img_new = draw(img, [drawable], [color])
+
+Draws the `drawable` object on a copy of image `img` using color
+`color`. Can also draw multiple `Drawable` objects when passed
+as a `Vector{Drawable}` with corresponding colors in `[color]` 
+"""
+draw{T<:Colorant}(img::AbstractArray{T,2}, args...) = draw!(copy(img), args...)
+
+Point(p::CartesianIndex) = Point(p[2], p[1])
+
+function draw!{T<:Colorant}(img::AbstractArray{T,2}, point::Point, color::T)
+    if CartesianIndex(point.y, point.x) ∈ CartesianRange(size(img))
+        img[point.y, point.x] = color
+    end
+    img
+end

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,7 +1,7 @@
 """
 Type representing any object drawable on image
 """
-abstract Drawable
+@compat abstract type Drawable end
 
 """
     p = Point(x,y)
@@ -14,8 +14,8 @@ immutable Point <: Drawable
     y::Int
 end
 
-abstract Line <: Drawable
-abstract Circle <: Drawable
+@compat abstract type Line <: Drawable end
+@compat abstract type Circle <: Drawable end
 
 
 """

--- a/src/ellipse2d.jl
+++ b/src/ellipse2d.jl
@@ -1,30 +1,15 @@
-"""
-```
-img_with_ellipse = ellipse(img, center, radiusy, radiusx)
-img_with_ellipse = ellipse(img, center, color, radiusy, radiusx)
-img_with_ellipse = ellipse(img, y, x, radiusy, radiusx)
-img_with_ellipse = ellipse(img, y, x, color, radiusy, radiusx)
-```
-Draws a ellipse on the input image given the `center` as a `CartesianIndex{2}` or
-as coordinates `(y, x)` using the specified `color`. If `color` is not specified,
-`one(eltype(img))` is used.
-"""
-ellipse{T<:Colorant}(img::AbstractArray{T, 2}, args...) = ellipse!(copy(img), args...)
+#Ellipse methods
 
-function ellipse!{T<:Colorant}(img::AbstractArray{T, 2}, center::CartesianIndex{2}, color::T, radiusy::Real, radiusx::Real)
-    ellipse!(img, center[1], center[2], color, radiusy, radiusx)
-end
+Ellipse(x::Int, y::Int, ρx::Real, ρy::Real) = Ellipse(Point(x,y), ρx, ρy)
+Ellipse(p::CartesianIndex{2}, ρx::Real, ρy::Real) = Ellipse(Point(p), ρx, ρy)
+Ellipse(circle::CirclePointRadius) = Ellipse(circle.center, circle.ρ, circle.ρ)
 
-function ellipse!{T<:Colorant}(img::AbstractArray{T, 2}, y::Int, x::Int, radiusy::Real, radiusx::Real)
-	ellipse!(img, y, x, one(T), radiusy, radiusx)
-end
-
-function ellipse!{T<:Colorant}(img::AbstractArray{T, 2}, y::Int, x::Int, color::T, radiusy::Real, radiusx::Real)
+function draw!{T<:Colorant}(img::AbstractArray{T, 2}, ellipse::Ellipse, color::T)
 	ys = Int[]
 	xs = Int[]
-	for i in y : y + radiusy
-		for j in x : x + radiusx
-			val = ((i - y) / radiusy) ^ 2 + ((j - x) / radiusx) ^ 2
+	for i in ellipse.center.y : ellipse.center.y + ellipse.ρy
+		for j in ellipse.center.x : ellipse.center.x + ellipse.ρx
+			val = ((i - ellipse.center.y) / ellipse.ρy) ^ 2 + ((j - ellipse.center.x) / ellipse.ρx) ^ 2
 			if val < 1
 				push!(ys, i)
 				push!(xs, j)
@@ -33,9 +18,9 @@ function ellipse!{T<:Colorant}(img::AbstractArray{T, 2}, y::Int, x::Int, color::
 	end
 	for (yi, xi) in zip(ys, xs)
 		img[yi, xi] = color
-		img[2 * y - yi, xi] = color
-		img[yi, 2 * x - xi] = color
-		img[2 * y - yi, 2 * x - xi] = color
+		img[2 * ellipse.center.y - yi, xi] = color
+		img[yi, 2 * ellipse.center.x - xi] = color
+		img[2 * ellipse.center.y - yi, 2 * ellipse.center.x - xi] = color
 	end
 	img
 end

--- a/src/ellipse2d.jl
+++ b/src/ellipse2d.jl
@@ -1,7 +1,7 @@
 #Ellipse methods
 
-Ellipse(x::Int, y::Int, ρx::Real, ρy::Real) = Ellipse(Point(x,y), ρx, ρy)
-Ellipse(p::CartesianIndex{2}, ρx::Real, ρy::Real) = Ellipse(Point(p), ρx, ρy)
+Ellipse{T<:Real, U<:Real}(x::Int, y::Int, ρx::T, ρy::U) = Ellipse(Point(x,y), ρx, ρy)
+Ellipse{T<:Real, U<:Real}(p::CartesianIndex{2}, ρx::T, ρy::U) = Ellipse(Point(p), ρx, ρy)
 Ellipse(circle::CirclePointRadius) = Ellipse(circle.center, circle.ρ, circle.ρ)
 
 function draw!{T<:Colorant}(img::AbstractArray{T, 2}, ellipse::Ellipse, color::T)

--- a/src/line2d.jl
+++ b/src/line2d.jl
@@ -1,8 +1,8 @@
 
 #Function to return valid intersections of lines with image boundary
 
-function get_valid_intersections(intersections::Vector{Tuple{Real, Real}}, indsx::Base.OneTo{Int}, indsy::Base.OneTo{Int})
-    valid_intersections = Vector{Tuple{Number,Number}}(0)
+function get_valid_intersections{T<:Real, U<:Real}(intersections::Vector{Tuple{T,U}}, indsx::AbstractUnitRange, indsy::AbstractUnitRange)
+    valid_intersections = Vector{Tuple{T,U}}(0)
     for intersection in intersections
         if first(indsx) <= intersection[1] <= last(indsx) && first(indsy) <= intersection[2] <= last(indsy)
             push!(valid_intersections,intersection)
@@ -37,7 +37,7 @@ end
 
 # LineNormal methods
 
-LineNormal(τ::Tuple{Number,Number}) = LineNormal(τ...)
+LineNormal{T<:Real, U<:Real}(τ::Tuple{T,U}) = LineNormal(τ...)
 
 draw!{T<:Colorant}(img::AbstractArray{T,2}, line::LineNormal, method::Function = bresenham) =
     draw!(img, line, one(T), method)

--- a/src/line2d.jl
+++ b/src/line2d.jl
@@ -1,76 +1,32 @@
-abstract Line
 
-immutable LineTwoPoints <: Line
-    y0::Number
-    x0::Number
-    y1::Number
-    x1::Number
-end
+#Function to return valid intersections of lines with image boundary
 
-LineTwoPoints(p1::CartesianIndex{2}, p2::CartesianIndex{2}) = LineTwoPoints(p1[1],p1[2],p2[1],p2[2])
-
-immutable LineNormal <: Line
-    ρ::Number
-    θ::Number
-end
-
-LineNormal(τ::Tuple{Number,Number}) = LineNormal(τ...)
-
-"""
-```
-img_with_line = line(img, l, color, method)
-img_with_line = line(img, LineTwoPoints(p1, p2), color, method)
-img_with_line = line(img, LineTwoPoints(y0, x0, y1, x1), color, method)
-img_with_line = line(img, LineNormal(ρ,θ), color, method)
-```
-
-Draws a line on the input image.
-img     =   Image to draw lines on
-l       =   A `Line` type object describing the line to be drawn.
-            A line can be represented in "two-points form" using `LineTwoPoints(p1,p2)`
-            where points p1, p2 are `CartesianIndex{2}`.
-            It can also be represented in "two-points form" using `LineTwoPoints(y0,x0,y1,x1)`
-            A line can also be represented in "normal form" using `LineNormal(ρ,θ)`
-            where ρ = perpendicular distance of line and θ is angle from x-axis in radians.
-color   =   Color of the line to be drawn
-method  =   Lines are drawn using the `bresenham` method by default. If anti-aliasing
-            is required, the `xiaolin_wu` can be used.
-
-"""
-
-#methods for LineTwoPoints parametrization
-
-line{T<:Colorant}(img::AbstractArray{T, 2}, args...) = line!(copy(img), args...)
-
-line!{T<:Colorant}(img::AbstractArray{T, 2}, p1::CartesianIndex{2}, p2::CartesianIndex{2}, method::Function = bresenham) =
-    line!(img, LineTwoPoints(p1, p2), one(T), method)
-
-line!{T<:Colorant}(img::AbstractArray{T, 2}, p1::CartesianIndex{2}, p2::CartesianIndex{2}, color::T, method::Function = bresenham) =
-    line!(img, LineTwoPoints(p1, p2), color, method)
-
-line!{T<:Colorant}(img::AbstractArray{T, 2}, y0::Int, x0::Int, y1::Int, x1::Int, method::Function = bresenham) = line!(img, y0, x0, y1, x1, one(T), method)
-line!{T<:Colorant}(img::AbstractArray{T, 2}, y0::Int, x0::Int, y1::Int, x1::Int, color::T, method::Function = bresenham) = method(img, y0, x0, y1, x1, color)
-
-line!{T<:Colorant}(img::AbstractArray{T, 2}, l::LineTwoPoints, method::Function = bresenham) = line!(img, l, one(T), method)
-line!{T<:Colorant}(img::AbstractArray{T, 2}, l::LineTwoPoints, color::T, method::Function = bresenham) = method(img, l.y0, l.x0, l.y1, l.x1, color)
-
-# methods for LineNormal parametrization
-
-line!{T<:Colorant}(img::AbstractArray{T, 2}, l::LineNormal, method::Function = bresenham) = 
-    line!(img, l, one(T), method)
-
-function line!{T<:Colorant}(img::AbstractArray{T, 2}, l::LineNormal, color::T, method::Function = bresenham)
-    indsy, indsx = indices(img)
-    cosθ = cos(l.θ)
-    sinθ = sin(l.θ)
-    intersections_x = [(x, (l.ρ - x*cosθ)/sinθ) for x in (first(indsx), last(indsx))]
-    intersections_y = [((l.ρ - y*sinθ)/cosθ, y) for y in (first(indsy), last(indsy))]
+function get_valid_intersections(intersections::Vector{Tuple{Real, Real}}, indsx::Base.OneTo{Int}, indsy::Base.OneTo{Int})
     valid_intersections = Vector{Tuple{Number,Number}}(0)
-    for intersection in vcat(intersections_x, intersections_y)
-        if 1 <= intersection[1] <= indsx.stop && 1 <= intersection[2] <= indsy.stop
+    for intersection in intersections
+        if first(indsx) <= intersection[1] <= last(indsx) && first(indsy) <= intersection[2] <= last(indsy)
             push!(valid_intersections,intersection)
         end
     end
+    valid_intersections
+end
+
+# LineTwoPoints methods
+
+LineTwoPoints(x0::Int, y0::Int, x1::Int, y1::Int) = LineTwoPoints(Point(x0, y0), Point(x1,y1))
+LineTwoPoints(p1::CartesianIndex{2}, p2::CartesianIndex{2}) = LineTwoPoints(Point(p1), Point(p2))
+
+draw!{T<:Colorant}(img::AbstractArray{T,2}, line::LineTwoPoints, method::Function = bresenham) =
+    draw!(img, line, one(T), method)
+
+function draw!{T<:Colorant}(img::AbstractArray{T,2}, line::LineTwoPoints, color::T, method::Function = bresenham)
+    indsy, indsx = indices(img)
+    x1 = line.p1.x; y1 = line.p1.y
+    x2 = line.p2.x; y2 = line.p2.y
+    m = (y2 - y1) / (x2 - x1)
+    intersections_x = [(x, y1 + m*(x-x1)) for x in (first(indsx), last(indsx))]
+    intersections_y = [(x1 + (y-y1)/m, y) for y in (first(indsy), last(indsy))]
+    valid_intersections = get_valid_intersections(vcat(intersections_x, intersections_y), indsx, indsy)
     if length(valid_intersections) > 0
         method(img, round(Int,valid_intersections[1][2]), round(Int,valid_intersections[1][1]), round(Int,valid_intersections[2][2]), round(Int,valid_intersections[2][1]), color)
     else
@@ -79,6 +35,39 @@ function line!{T<:Colorant}(img::AbstractArray{T, 2}, l::LineNormal, color::T, m
 end
 
 
+# LineNormal methods
+
+LineNormal(τ::Tuple{Number,Number}) = LineNormal(τ...)
+
+draw!{T<:Colorant}(img::AbstractArray{T,2}, line::LineNormal, method::Function = bresenham) =
+    draw!(img, line, one(T), method)
+
+function draw!{T<:Colorant}(img::AbstractArray{T, 2}, line::LineNormal, color::T, method::Function = bresenham)
+    indsy, indsx = indices(img)
+    cosθ = cos(line.θ)
+    sinθ = sin(line.θ)
+    intersections_x = [(x, (line.ρ - x*cosθ)/sinθ) for x in (first(indsx), last(indsx))]
+    intersections_y = [((line.ρ - y*sinθ)/cosθ, y) for y in (first(indsy), last(indsy))]
+    valid_intersections = get_valid_intersections(vcat(intersections_x, intersections_y), indsx, indsy)
+    if length(valid_intersections) > 0
+        method(img, round(Int,valid_intersections[1][2]), round(Int,valid_intersections[1][1]), round(Int,valid_intersections[2][2]), round(Int,valid_intersections[2][1]), color)
+    else
+        img
+    end
+end
+
+# LineSegment methods
+
+LineSegment(x0::Int, y0::Int, x1::Int, y1::Int) = LineSegment(Point(x0, y0), Point(x1,y1))
+LineSegment(p1::CartesianIndex, p2::CartesianIndex) = LineSegment(Point(p1), Point(p2))
+
+draw!{T<:Colorant}(img::AbstractArray{T,2}, line::LineSegment, method::Function = bresenham) =
+    draw!(img, line, one(T), method)
+
+draw!{T<:Colorant}(img::AbstractArray{T,2}, line::LineSegment, color::T, method::Function = bresenham) =
+    method(img, line.p1.y, line.p1.x, line.p2.y, line.p2.x, color)
+
+# Methods to draw lines
 
 function bresenham{T<:Colorant}(img::AbstractArray{T, 2}, y0::Int, x0::Int, y1::Int, x1::Int, color::T)
     dx = abs(x1 - x0)
@@ -110,10 +99,7 @@ fpart{T}(pixel::T) = pixel - T(trunc(pixel))
 rfpart{T}(pixel::T) = one(T) - fpart(pixel)
 
 function swap(x, y)
-    temp = y
-    y = x
-    x = temp
-    x, y
+    y, x
 end
 
 function xiaolin_wu{T<:Gray}(img::AbstractArray{T, 2}, y0::Int, x0::Int, y1::Int, x1::Int, color::T)

--- a/src/paths.jl
+++ b/src/paths.jl
@@ -1,18 +1,10 @@
-"""
+#Path methods
 
-Draws lines segments connecting input points.
-Parameters:
-img: 2d array
-vertices: coordinates of points as array of CartesianIndex
-color (optional): color of line segments
-closed (keyword): whether to connect first and last points
+Path(v::Vector{Tuple{Int, Int}}) = Path([Point(p...) for p in v])
+Path(v::Vector{CartesianIndex{2}}) = Path([Point(p) for p in v])
 
-In case a point is out-of-bounds, it throws an error after drawing the line segments till that point.
-"""
-
-path{T<:Colorant}(img::AbstractArray{T, 2}, vertices::Array{CartesianIndex{2},1}, color::T=one(T); closed::Bool=true) = path!(copy(img),vertices,color,closed=closed)
-
-function path!{T<:Colorant}(img::AbstractArray{T, 2}, vertices::Array{CartesianIndex{2},1}, color::T=one(T); closed::Bool=true)
+function draw!{T<:Colorant}(img::AbstractArray{T, 2}, path::Path, color::T)
+    vertices = [CartesianIndex(p.y, p.x) for p in path.vertices]
     f = CartesianIndex(map(r->first(r)-1, indices(img)))
     l = CartesianIndex(map(r->last(r), indices(img)))
 
@@ -23,14 +15,32 @@ function path!{T<:Colorant}(img::AbstractArray{T, 2}, vertices::Array{CartesianI
 
     for i in 1:length(vertices)-1
         if min(f,vertices[i+1])==f && max(l,vertices[i+1])==l
-            line!(img, vertices[i], vertices[i+1], color)
+            draw!(img, LineSegment(vertices[i], vertices[i+1]), color)
         else
             println(vertices[i+1])
             error("Point coordinates out of range.")
         end
     end
+end
 
-    if closed==true
-        line!(img, vertices[1], vertices[end], color)
-    end
+#Polygon methods
+
+Polygon(v::Vector{Tuple{Int, Int}}) = Polygon([Point(p...) for p in v])
+Polygon(v::Vector{CartesianIndex{2}}) = Polygon([Point(p) for p in v])
+
+function draw!{T<:Colorant}(img::AbstractArray{T, 2}, polygon::Polygon, color::T)
+    draw!(img, Path(polygon.vertices), color)
+    draw!(img, LineSegment(first(polygon.vertices), last(polygon.vertices)), color)
+end
+
+#RegularPolygon methods
+
+RegularPolygon(point::CartesianIndex{2}, side_count::Int, side_length::Real, θ::Real) =
+    RegularPolygon(Point(point), side_count, side_length, θ)
+
+function draw!{T<:Colorant}(img::AbstractArray{T, 2}, rp::RegularPolygon, color::T)
+    n = rp.side_count
+    ρ = rp.side_length/(2*sin(π/n))
+    polygon = Polygon([ Point(round(Int, rp.center.x + ρ*cos(rp.θ + 2π*k/n)), round(Int, rp.center.y + ρ*sin(rp.θ + 2π*k/n))) for k in 1:n ])
+    draw!(img, polygon, color)
 end

--- a/src/paths.jl
+++ b/src/paths.jl
@@ -1,7 +1,7 @@
 #Path methods
 
-Path(v::Vector{Tuple{Int, Int}}) = Path([Point(p...) for p in v])
-Path(v::Vector{CartesianIndex{2}}) = Path([Point(p) for p in v])
+Path(v::AbstractVector{Tuple{Int, Int}}) = Path([Point(p...) for p in v])
+Path(v::AbstractVector{CartesianIndex{2}}) = Path([Point(p) for p in v])
 
 function draw!{T<:Colorant}(img::AbstractArray{T, 2}, path::Path, color::T)
     vertices = [CartesianIndex(p.y, p.x) for p in path.vertices]
@@ -25,8 +25,8 @@ end
 
 #Polygon methods
 
-Polygon(v::Vector{Tuple{Int, Int}}) = Polygon([Point(p...) for p in v])
-Polygon(v::Vector{CartesianIndex{2}}) = Polygon([Point(p) for p in v])
+Polygon(v::AbstractVector{Tuple{Int, Int}}) = Polygon([Point(p...) for p in v])
+Polygon(v::AbstractVector{CartesianIndex{2}}) = Polygon([Point(p) for p in v])
 
 function draw!{T<:Colorant}(img::AbstractArray{T, 2}, polygon::Polygon, color::T)
     draw!(img, Path(polygon.vertices), color)
@@ -35,7 +35,7 @@ end
 
 #RegularPolygon methods
 
-RegularPolygon(point::CartesianIndex{2}, side_count::Int, side_length::Real, θ::Real) =
+RegularPolygon{T<:Real, U<:Real}(point::CartesianIndex{2}, side_count::Int, side_length::T, θ::U) =
     RegularPolygon(Point(point), side_count, side_length, θ)
 
 function draw!{T<:Colorant}(img::AbstractArray{T, 2}, rp::RegularPolygon, color::T)

--- a/test/circle2d.jl
+++ b/test/circle2d.jl
@@ -58,5 +58,8 @@
         invalid_circle = CircleThreePoints(Point(1,1), Point(2,2), Point(3,3))
         @test_throws ErrorException draw(img, invalid_circle)
 
+        invalid_circle = CircleThreePoints(Point(1,1), Point(5,5), Point(10,1))
+        @test_throws ErrorException draw(img, invalid_circle)
+
     end
 end

--- a/test/circle2d.jl
+++ b/test/circle2d.jl
@@ -1,0 +1,62 @@
+@testset "Circle" begin
+    @testset "CirclePointRadius" begin
+        img = zeros(Gray{N0f8}, 10, 10)
+
+        expected = Gray{N0f8}[  0 0 1 1 1 1 1 0 0 0
+                                0 1 1 1 1 1 1 1 0 0
+                                1 1 1 1 1 1 1 1 1 0
+                                1 1 1 1 1 1 1 1 1 0
+                                1 1 1 1 1 1 1 1 1 0
+                                1 1 1 1 1 1 1 1 1 0
+                                1 1 1 1 1 1 1 1 1 0
+                                0 1 1 1 1 1 1 1 0 0
+                                0 0 1 1 1 1 1 0 0 0
+                                0 0 0 0 0 0 0 0 0 0 ]
+
+        res = @inferred draw(img, CirclePointRadius(Point(5,5), 5))
+        @test all(expected .== res) == true
+
+        res = @inferred draw(img, CirclePointRadius(5, 5, 5))
+        @test all(expected .== res) == true
+
+        res = @inferred draw(img, CirclePointRadius(CartesianIndex(5,5), 5))
+        @test all(expected .== res) == true
+
+        res = @inferred draw(img, CirclePointRadius(Point(5,5), 5), Gray{N0f8}(0.5))
+        expected = map(i->(i==1 ? Gray{N0f8}(0.5) : Gray{N0f8}(0)), expected)
+        @test all(expected .== res) == true
+
+    end
+
+    @testset "CircleThreePoints" begin
+        img = zeros(Gray{N0f8}, 10, 10)
+
+        expected = Gray{N0f8}[ 0 0 0 0 0 0 0 0 0 0
+                               0 0 0 1 1 1 1 1 0 0
+                               0 0 1 1 1 1 1 1 1 0
+                               0 1 1 1 1 1 1 1 1 1
+                               0 1 1 1 1 1 1 1 1 1
+                               0 1 1 1 1 1 1 1 1 1
+                               0 1 1 1 1 1 1 1 1 1
+                               0 1 1 1 1 1 1 1 1 1
+                               0 0 1 1 1 1 1 1 1 0
+                               0 0 0 1 1 1 1 1 0 0 ]
+
+        res = @inferred draw(img, CircleThreePoints(Point(1,5), Point(5,1), Point(10,5)))
+        @test all(expected .== res)
+
+        res = @inferred draw(img, CircleThreePoints(1,5, 5,1, 10,5))
+        @test all(expected .== res)
+
+        res = @inferred draw(img, CircleThreePoints(CartesianIndex(5,1), CartesianIndex(1,5), CartesianIndex(5,10)))
+        @test all(expected .== res)
+
+        res = @inferred draw(img, CircleThreePoints(Point(1,5), Point(5,1), Point(10,5)), Gray{N0f8}(0.5))
+        expected = map(i->(i==1 ? Gray{N0f8}(0.5) : Gray{N0f8}(0)), expected)
+        @test all(expected .== res) == true
+
+        invalid_circle = CircleThreePoints(Point(1,1), Point(2,2), Point(3,3))
+        @test_throws ErrorException draw(img, invalid_circle)
+
+    end
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,0 +1,38 @@
+@testset "Core" begin
+
+    points = [Point(1,1), Point(2,2), Point(3,3)]
+    img = zeros(Gray{N0f8}, 3, 3)
+    draw!(img, points)
+    expected = diagm([1,1,1])
+    @test all(img .== expected) == true
+
+    img = zeros(Gray{N0f8}, 3, 3)
+    draw!(img, points, Gray{N0f8}(0.8))
+    expected = diagm([0.8,0.8,0.8])
+    @test all(img .== expected) == true
+
+    img = zeros(Gray{N0f8}, 3, 3)
+    draw!(img, points, [Gray{N0f8}(0.8)])
+    expected = diagm([0.8,1,1])
+    @test all(img .== expected) == true
+
+    points = [Point((1,1)), Point((2,2)), Point((3,3))]
+    img = zeros(Gray{N0f8}, 3, 3)
+    draw!(img, points)
+    expected = diagm([1,1,1])
+    @test all(img .== expected) == true
+
+    ci = [CartesianIndex(1,2), CartesianIndex(1,3), CartesianIndex(3,1)]
+    points = [Point(i) for i in ci]
+    img = zeros(Gray{N0f8}, 3, 3)
+    expected = copy(img)
+    draw!(img, points)
+    expected[1,2] = expected[1,3] = expected[3,1] = one(Gray{N0f8})
+    @test all(img .== expected) == true
+
+    point = Point(4,1)
+    img = zeros(Gray{N0f8}, 3, 3)
+    draw!(img, point)
+    expected = zeros(Gray{N0f8})
+    @test all(img .== expected) == true
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -2,23 +2,23 @@
 
     points = [Point(1,1), Point(2,2), Point(3,3)]
     img = zeros(Gray{N0f8}, 3, 3)
-    draw!(img, points)
+    @inferred draw!(img, points)
     expected = diagm([1,1,1])
     @test all(img .== expected) == true
 
     img = zeros(Gray{N0f8}, 3, 3)
-    draw!(img, points, Gray{N0f8}(0.8))
+    @inferred draw!(img, points, Gray{N0f8}(0.8))
     expected = diagm([0.8,0.8,0.8])
     @test all(img .== expected) == true
 
     img = zeros(Gray{N0f8}, 3, 3)
-    draw!(img, points, [Gray{N0f8}(0.8)])
+    @inferred draw!(img, points, [Gray{N0f8}(0.8)])
     expected = diagm([0.8,1,1])
     @test all(img .== expected) == true
 
     points = [Point((1,1)), Point((2,2)), Point((3,3))]
     img = zeros(Gray{N0f8}, 3, 3)
-    draw!(img, points)
+    @inferred draw!(img, points)
     expected = diagm([1,1,1])
     @test all(img .== expected) == true
 
@@ -26,13 +26,13 @@
     points = [Point(i) for i in ci]
     img = zeros(Gray{N0f8}, 3, 3)
     expected = copy(img)
-    draw!(img, points)
+    @inferred draw!(img, points)
     expected[1,2] = expected[1,3] = expected[3,1] = one(Gray{N0f8})
     @test all(img .== expected) == true
 
     point = Point(4,1)
     img = zeros(Gray{N0f8}, 3, 3)
-    draw!(img, point)
+    @inferred draw!(img, point)
     expected = zeros(Gray{N0f8})
     @test all(img .== expected) == true
 end

--- a/test/ellipse2d.jl
+++ b/test/ellipse2d.jl
@@ -1,0 +1,41 @@
+@testset "Ellipse" begin
+    
+    img = zeros(Gray{N0f8}, 10, 10)
+    expected = copy(img)
+    res = @inferred draw(img, Ellipse(Point(5,5), 5, 1))
+    expected[5, 1:9] = 1
+    @test all(expected .== res) == true
+
+    res = @inferred draw(img, Ellipse(5, 5, 5, 5), one(Gray{N0f8}))
+    expected = Gray{N0f8}[  0 0 1 1 1 1 1 0 0 0
+                            0 1 1 1 1 1 1 1 0 0
+                            1 1 1 1 1 1 1 1 1 0
+                            1 1 1 1 1 1 1 1 1 0
+                            1 1 1 1 1 1 1 1 1 0
+                            1 1 1 1 1 1 1 1 1 0
+                            1 1 1 1 1 1 1 1 1 0
+                            0 1 1 1 1 1 1 1 0 0
+                            0 0 1 1 1 1 1 0 0 0
+                            0 0 0 0 0 0 0 0 0 0 ]
+    @test all(expected .== res) == true
+
+    res = @inferred draw(img, Ellipse(CirclePointRadius(5,5,5)))
+    @test all(expected .== res) == true
+
+    res = @inferred draw(img, Ellipse(5, 5, 5, 5), Gray{N0f8}(0.5))
+    expected = map(i->(i==1 ? Gray{N0f8}(0.5) : Gray{N0f8}(0)), expected)
+    @test all(expected .== res) == true
+
+    res = @inferred draw(img, Ellipse(CartesianIndex(5,5), 5, 3))
+    expected = Gray{N0f8}[  0 0 0 0 0 0 0 0 0 0
+                            0 0 0 0 0 0 0 0 0 0
+                            0 1 1 1 1 1 1 1 0 0
+                            1 1 1 1 1 1 1 1 1 0
+                            1 1 1 1 1 1 1 1 1 0
+                            1 1 1 1 1 1 1 1 1 0
+                            0 1 1 1 1 1 1 1 0 0
+                            0 0 0 0 0 0 0 0 0 0
+                            0 0 0 0 0 0 0 0 0 0
+                            0 0 0 0 0 0 0 0 0 0 ]
+    @test all(expected .== res) == true
+end

--- a/test/line2d.jl
+++ b/test/line2d.jl
@@ -1,32 +1,32 @@
 @testset "Lines2D" begin
 
-	@testset "Lines API" begin
+	@testset "LineSegment" begin
 		img = zeros(Gray{N0f8}, 10, 10)
 		expected = copy(img)
 		expected[diagind(expected)] = one(Gray{N0f8})
-		res = line(img, 1, 1, 10, 10)
+		res = draw(img, LineSegment(1,1,10,10))
 		@test expected == res
-		res = line(img, 1, 1, 10, 10, bresenham)
+		res = draw(img, LineSegment(1,1,10,10), bresenham)
 		@test expected == res
-		res = line(img, 1, 1, 10, 10, one(Gray{N0f8}), bresenham)
+		res = draw(img, LineSegment(1,1,10,10), one(Gray), bresenham)
 		@test expected == res
-		res = line(img, 1, 1, 10, 10, one(Gray{N0f8}))
+		res = draw(img, LineSegment(1,1,10,10), one(Gray))
 		@test expected == res
-		res = line(img, CartesianIndex(1, 1), CartesianIndex(10, 10))
+		res = draw(img, LineSegment(CartesianIndex(1, 1), CartesianIndex(10, 10)))
 		@test expected == res
-		res = line(img, CartesianIndex(1, 1), CartesianIndex(10, 10), bresenham)
+		res = draw(img, LineSegment(CartesianIndex(1, 1), CartesianIndex(10, 10)), bresenham)
 		@test expected == res
-		res = line(img, CartesianIndex(1, 1), CartesianIndex(10, 10), one(Gray{N0f8}), bresenham)
+		res = draw(img, LineSegment(CartesianIndex(1, 1), CartesianIndex(10, 10)), one(Gray), bresenham)
 		@test expected == res
-		res = line(img, CartesianIndex(1, 1), CartesianIndex(10, 10), one(Gray{N0f8}))
+		res = draw(img, LineSegment(CartesianIndex(1, 1), CartesianIndex(10, 10)), one(Gray))
 		@test expected == res
 		expected[diagind(expected)] = Gray{N0f8}(0.5)
-		res = line(img, 1, 1, 10, 10, Gray{N0f8}(0.5))
+		res = draw(img, LineSegment(1,1,10,10), Gray{N0f8}(0.5))
 		@test expected == res
 		img2 = zeros(RGB, 10, 10)
 		expected = copy(img2)
 		expected[diagind(expected)] = RGB{N0f8}(0.2, 0.3, 0.4)
-		res = line(img2, 1, 1, 10, 10, RGB{N0f8}(0.2, 0.3, 0.4))
+		res = draw(img2, LineSegment(1,1,10,10), RGB{N0f8}(0.2,0.3,0.4))
 		@test expected == res
 	end
 
@@ -154,24 +154,24 @@
 		img = zeros(Gray, 10, 10)
 		expected = copy(img)
 		expected[1:10, 1] = 1
-		line!(img, LineNormal(1, 0))
+		draw!(img, LineNormal(1, 0))
 		@test img == expected
 		fill!(img,zero(Gray))
-		@test line(img, LineNormal(1, 0)) == expected
+		@test draw(img, LineNormal(1, 0)) == expected
 		expected[1:10, 1] = Gray(0.5)
-		@test line(img, LineNormal(1, 0), Gray(0.5)) == expected
+		@test draw(img, LineNormal(1, 0), Gray(0.5)) == expected
 		fill!(expected,zero(Gray))
 		expected[1:10,2] = expected[1:10,7] = expected[10,1:10] = Gray(0.3)
-		line!(img, LineNormal(2, 0), Gray(0.3))
-		line!(img, LineNormal(7, 0), Gray(0.3))
-		line!(img, LineNormal(10, π/2), Gray(0.3))
+		draw!(img, LineNormal(2, 0), Gray(0.3))
+		draw!(img, LineNormal(7, 0), Gray(0.3))
+		draw!(img, LineNormal(10, π/2), Gray(0.3))
 		@test img == expected
 		fill!(img,zero(Gray))
 		fill!(expected,zero(Gray))
 		for i in 1:10
 			expected[i,10-i+1] = 1
 		end
-		@test line(img, LineNormal(7.5, π/4)) == expected
+		@test draw(img, LineNormal(7.5, π/4)) == expected
 		for i in 1:10
 			expected[i,10-i+1] = 0.8
 		end
@@ -179,11 +179,41 @@
 		for i in 1:10
 			expected[i,i] = Gray(0.8)
 		end
-		@test line(img, LineNormal((0,-π/4)), Gray(0.8)) == expected
+		@test draw(img, LineNormal((0,-π/4)), Gray(0.8)) == expected
 		img = zeros(Gray,3,3)
 		expected = copy(img)
-		@test line(img, LineNormal(4,0)) == expected
-		@test line(img, LineNormal(4,π/2)) == expected
-		@test line(img, LineNormal(5,π/4)) == expected
+		@test draw(img, LineNormal(4,0)) == expected
+		@test draw(img, LineNormal(4,π/2)) == expected
+		@test draw(img, LineNormal(5,π/4)) == expected
+	end
+
+	@testset "LineTwoPoints" begin
+		img = zeros(Gray{N0f8}, 10, 10)
+		expected = copy(img)
+		expected[diagind(expected)] = one(Gray{N0f8})
+		res = draw(img, LineTwoPoints(1,1,10,10))
+		@test expected == res
+		res = draw(img, LineTwoPoints(1,1,10,10), bresenham)
+		@test expected == res
+		res = draw(img, LineTwoPoints(1,1,10,10), one(Gray), bresenham)
+		@test expected == res
+		res = draw(img, LineTwoPoints(1,1,10,10), one(Gray))
+		@test expected == res
+		res = draw(img, LineTwoPoints(CartesianIndex(1, 1), CartesianIndex(10, 10)))
+		@test expected == res
+		res = draw(img, LineTwoPoints(CartesianIndex(1, 1), CartesianIndex(10, 10)), bresenham)
+		@test expected == res
+		res = draw(img, LineTwoPoints(CartesianIndex(1, 1), CartesianIndex(10, 10)), one(Gray), bresenham)
+		@test expected == res
+		res = draw(img, LineTwoPoints(CartesianIndex(1, 1), CartesianIndex(10, 10)), one(Gray))
+		@test expected == res
+		expected[diagind(expected)] = Gray{N0f8}(0.5)
+		res = draw(img, LineTwoPoints(1,1,10,10), Gray{N0f8}(0.5))
+		@test expected == res
+		img2 = zeros(RGB, 10, 10)
+		expected = copy(img2)
+		expected[diagind(expected)] = RGB{N0f8}(0.2, 0.3, 0.4)
+		res = draw(img2, LineTwoPoints(1,1,10,10), RGB{N0f8}(0.2,0.3,0.4))
+		@test expected == res
 	end
 end

--- a/test/line2d.jl
+++ b/test/line2d.jl
@@ -215,5 +215,6 @@
 		expected[diagind(expected)] = RGB{N0f8}(0.2, 0.3, 0.4)
 		res = draw(img2, LineTwoPoints(1,1,10,10), RGB{N0f8}(0.2,0.3,0.4))
 		@test expected == res
+		@test img2 == draw(img2, LineTwoPoints(1,11,10,11))
 	end
 end

--- a/test/line2d.jl
+++ b/test/line2d.jl
@@ -4,29 +4,29 @@
 		img = zeros(Gray{N0f8}, 10, 10)
 		expected = copy(img)
 		expected[diagind(expected)] = one(Gray{N0f8})
-		res = draw(img, LineSegment(1,1,10,10))
+		res = @inferred draw(img, LineSegment(1,1,10,10))
 		@test expected == res
-		res = draw(img, LineSegment(1,1,10,10), bresenham)
+		res = @inferred draw(img, LineSegment(1,1,10,10), bresenham)
 		@test expected == res
-		res = draw(img, LineSegment(1,1,10,10), one(Gray), bresenham)
+		res = @inferred draw(img, LineSegment(1,1,10,10), one(Gray), bresenham)
 		@test expected == res
-		res = draw(img, LineSegment(1,1,10,10), one(Gray))
+		res = @inferred draw(img, LineSegment(1,1,10,10), one(Gray))
 		@test expected == res
-		res = draw(img, LineSegment(CartesianIndex(1, 1), CartesianIndex(10, 10)))
+		res = @inferred draw(img, LineSegment(CartesianIndex(1, 1), CartesianIndex(10, 10)))
 		@test expected == res
-		res = draw(img, LineSegment(CartesianIndex(1, 1), CartesianIndex(10, 10)), bresenham)
+		res = @inferred draw(img, LineSegment(CartesianIndex(1, 1), CartesianIndex(10, 10)), bresenham)
 		@test expected == res
-		res = draw(img, LineSegment(CartesianIndex(1, 1), CartesianIndex(10, 10)), one(Gray), bresenham)
+		res = @inferred draw(img, LineSegment(CartesianIndex(1, 1), CartesianIndex(10, 10)), one(Gray), bresenham)
 		@test expected == res
-		res = draw(img, LineSegment(CartesianIndex(1, 1), CartesianIndex(10, 10)), one(Gray))
+		res = @inferred draw(img, LineSegment(CartesianIndex(1, 1), CartesianIndex(10, 10)), one(Gray))
 		@test expected == res
 		expected[diagind(expected)] = Gray{N0f8}(0.5)
-		res = draw(img, LineSegment(1,1,10,10), Gray{N0f8}(0.5))
+		res = @inferred draw(img, LineSegment(1,1,10,10), Gray{N0f8}(0.5))
 		@test expected == res
 		img2 = zeros(RGB, 10, 10)
 		expected = copy(img2)
 		expected[diagind(expected)] = RGB{N0f8}(0.2, 0.3, 0.4)
-		res = draw(img2, LineSegment(1,1,10,10), RGB{N0f8}(0.2,0.3,0.4))
+		res = @inferred draw(img2, LineSegment(1,1,10,10), RGB{N0f8}(0.2,0.3,0.4))
 		@test expected == res
 	end
 
@@ -34,52 +34,52 @@
 		img = zeros(Gray{N0f8}, 10, 10)
 		expected = copy(img)
 		expected[diagind(expected)] = one(Gray{N0f8})
-		res = bresenham(copy(img), 1, 1, 10, 10, one(Gray{N0f8}))
+		res = @inferred bresenham(copy(img), 1, 1, 10, 10, one(Gray{N0f8}))
 		@test expected == res
 		expected = copy(img)
 		expected[diagind(expected)[1:5]] = one(Gray{N0f8})
-		res = bresenham(copy(img), 1, 1, 5, 5, one(Gray{N0f8}))
+		res = @inferred bresenham(copy(img), 1, 1, 5, 5, one(Gray{N0f8}))
 		@test expected == res
 
 		expected = copy(img)
 		expected[10, :] = one(Gray{N0f8})
-		res = bresenham(copy(img), 10, 1, 10, 10, one(Gray{N0f8}))
+		res = @inferred bresenham(copy(img), 10, 1, 10, 10, one(Gray{N0f8}))
 		@test expected == res
 		expected = copy(img)
 		expected[5, :] = one(Gray{N0f8})
-		res = bresenham(copy(img), 5, 1, 5, 10, one(Gray{N0f8}))
+		res = @inferred bresenham(copy(img), 5, 1, 5, 10, one(Gray{N0f8}))
 		@test expected == res
 		expected = copy(img)
 		expected[5, 1:5] = one(Gray{N0f8})
-		res = bresenham(copy(img), 5, 1, 5, 5, one(Gray{N0f8}))
+		res = @inferred bresenham(copy(img), 5, 1, 5, 5, one(Gray{N0f8}))
 		@test expected == res
 
 		expected = copy(img)
 		expected[:, 10] = one(Gray{N0f8})
-		res = bresenham(copy(img), 1, 10, 10, 10, one(Gray{N0f8}))
+		res = @inferred bresenham(copy(img), 1, 10, 10, 10, one(Gray{N0f8}))
 		@test expected == res
 		expected = copy(img)
 		expected[:, 5] = one(Gray{N0f8})
-		res = bresenham(copy(img), 1, 5, 10, 5, one(Gray{N0f8}))
+		res = @inferred bresenham(copy(img), 1, 5, 10, 5, one(Gray{N0f8}))
 		@test expected == res
 		expected = copy(img)
 		expected[1:5, 5] = one(Gray{N0f8})
-		res = bresenham(copy(img), 1, 5, 5, 5, one(Gray{N0f8}))
+		res = @inferred bresenham(copy(img), 1, 5, 5, 5, one(Gray{N0f8}))
 		@test expected == res
 
 		expected = copy(img)
 		expected[10:9:91] = one(Gray{N0f8})
-		res = bresenham(copy(img), 1, 10, 10, 1, one(Gray{N0f8}))
+		res = @inferred bresenham(copy(img), 1, 10, 10, 1, one(Gray{N0f8}))
 		@test expected == res
 		expected = copy(img)
 		expected[10:9:55] = one(Gray{N0f8})
-		res = bresenham(copy(img), 10, 1, 5, 6, one(Gray{N0f8}))
+		res = @inferred bresenham(copy(img), 10, 1, 5, 6, one(Gray{N0f8}))
 		@test expected == res
 
 		img2 = zeros(RGB, 10, 10)
 		expected = copy(img2)
 		expected[diagind(expected)] = RGB{N0f8}(0.2, 0.3, 0.4)
-		res = bresenham(copy(img2), 1, 1, 10, 10, RGB{N0f8}(0.2, 0.3, 0.4))
+		res = @inferred bresenham(copy(img2), 1, 1, 10, 10, RGB{N0f8}(0.2, 0.3, 0.4))
 		@test expected == res
 	end
 
@@ -89,64 +89,64 @@
 		expected[diagind(expected)] = one(Gray{N0f8})
 		expected[1, 1] = Gray{N0f8}(0.5)
 		expected[10, 10] = Gray{N0f8}(0.5)
-		res = xiaolin_wu(copy(img), 1, 1, 10, 10, one(Gray{N0f8}))
+		res = @inferred xiaolin_wu(copy(img), 1, 1, 10, 10, one(Gray{N0f8}))
 		@test expected == res
 		expected = copy(img)
 		expected[diagind(expected)[1:5]] = one(Gray{N0f8})
 		expected[1, 1] = Gray{N0f8}(0.5)
 		expected[5, 5] = Gray{N0f8}(0.5)
-		res = xiaolin_wu(copy(img), 1, 1, 5, 5, one(Gray{N0f8}))
+		res = @inferred xiaolin_wu(copy(img), 1, 1, 5, 5, one(Gray{N0f8}))
 		@test expected == res
 
 		expected = copy(img)
 		expected[10, :] = one(Gray{N0f8})
 		expected[10, 1] = Gray{N0f8}(0.5)
 		expected[10, 10] = Gray{N0f8}(0.5)
-		res = xiaolin_wu(copy(img), 10, 1, 10, 10, one(Gray{N0f8}))
+		res = @inferred xiaolin_wu(copy(img), 10, 1, 10, 10, one(Gray{N0f8}))
 		@test expected == res
 		expected = copy(img)
 		expected[5, :] = one(Gray{N0f8})
 		expected[5, 1] = Gray{N0f8}(0.5)
 		expected[5, 10] = Gray{N0f8}(0.5)
-		res = xiaolin_wu(copy(img), 5, 1, 5, 10, one(Gray{N0f8}))
+		res = @inferred xiaolin_wu(copy(img), 5, 1, 5, 10, one(Gray{N0f8}))
 		@test expected == res
 		expected = copy(img)
 		expected[5, 1:5] = one(Gray{N0f8})
 		expected[5, 1] = Gray{N0f8}(0.5)
 		expected[5, 5] = Gray{N0f8}(0.5)
-		res = xiaolin_wu(copy(img), 5, 1, 5, 5, one(Gray{N0f8}))
+		res = @inferred xiaolin_wu(copy(img), 5, 1, 5, 5, one(Gray{N0f8}))
 		@test expected == res
 
 		expected = copy(img)
 		expected[:, 10] = one(Gray{N0f8})
 		expected[1, 10] = Gray{N0f8}(0.5)
 		expected[10, 10] = Gray{N0f8}(0.5)
-		res = xiaolin_wu(copy(img), 1, 10, 10, 10, one(Gray{N0f8}))
+		res = @inferred xiaolin_wu(copy(img), 1, 10, 10, 10, one(Gray{N0f8}))
 		@test expected == res
 		expected = copy(img)
 		expected[:, 5] = one(Gray{N0f8})
 		expected[1, 5] = Gray{N0f8}(0.5)
 		expected[10, 5] = Gray{N0f8}(0.5)
-		res = xiaolin_wu(copy(img), 1, 5, 10, 5, one(Gray{N0f8}))
+		res = @inferred xiaolin_wu(copy(img), 1, 5, 10, 5, one(Gray{N0f8}))
 		@test expected == res
 		expected = copy(img)
 		expected[1:5, 5] = one(Gray{N0f8})
 		expected[1, 5] = Gray{N0f8}(0.5)
 		expected[5, 5] = Gray{N0f8}(0.5)
-		res = xiaolin_wu(copy(img), 1, 5, 5, 5, one(Gray{N0f8}))
+		res = @inferred xiaolin_wu(copy(img), 1, 5, 5, 5, one(Gray{N0f8}))
 		@test expected == res
 
 		expected = copy(img)
 		expected[10:9:91] = one(Gray{N0f8})
 		expected[10, 1] = Gray{N0f8}(0.5)
 		expected[1, 10] = Gray{N0f8}(0.5)
-		res = xiaolin_wu(copy(img), 1, 10, 10, 1, one(Gray{N0f8}))
+		res = @inferred xiaolin_wu(copy(img), 1, 10, 10, 1, one(Gray{N0f8}))
 		@test expected == res
 		expected = copy(img)
 		expected[10:9:55] = one(Gray{N0f8})
 		expected[10, 1] = Gray{N0f8}(0.5)
 		expected[5, 6] = Gray{N0f8}(0.5)
-		res = xiaolin_wu(copy(img), 10, 1, 5, 6, one(Gray{N0f8}))
+		res = @inferred xiaolin_wu(copy(img), 10, 1, 5, 6, one(Gray{N0f8}))
 		@test expected == res
 	end
 
@@ -154,24 +154,24 @@
 		img = zeros(Gray, 10, 10)
 		expected = copy(img)
 		expected[1:10, 1] = 1
-		draw!(img, LineNormal(1, 0))
+		@inferred draw!(img, LineNormal(1, 0))
 		@test img == expected
 		fill!(img,zero(Gray))
-		@test draw(img, LineNormal(1, 0)) == expected
+		@test @inferred draw(img, LineNormal(1, 0)) == expected
 		expected[1:10, 1] = Gray(0.5)
-		@test draw(img, LineNormal(1, 0), Gray(0.5)) == expected
+		@test @inferred draw(img, LineNormal(1, 0), Gray(0.5)) == expected
 		fill!(expected,zero(Gray))
 		expected[1:10,2] = expected[1:10,7] = expected[10,1:10] = Gray(0.3)
-		draw!(img, LineNormal(2, 0), Gray(0.3))
-		draw!(img, LineNormal(7, 0), Gray(0.3))
-		draw!(img, LineNormal(10, π/2), Gray(0.3))
+		@inferred draw!(img, LineNormal(2, 0), Gray(0.3))
+		@inferred draw!(img, LineNormal(7, 0), Gray(0.3))
+		@inferred draw!(img, LineNormal(10, π/2), Gray(0.3))
 		@test img == expected
 		fill!(img,zero(Gray))
 		fill!(expected,zero(Gray))
 		for i in 1:10
 			expected[i,10-i+1] = 1
 		end
-		@test draw(img, LineNormal(7.5, π/4)) == expected
+		@test @inferred draw(img, LineNormal(7.5, π/4)) == expected
 		for i in 1:10
 			expected[i,10-i+1] = 0.8
 		end
@@ -179,42 +179,42 @@
 		for i in 1:10
 			expected[i,i] = Gray(0.8)
 		end
-		@test draw(img, LineNormal((0,-π/4)), Gray(0.8)) == expected
+		@test @inferred draw(img, LineNormal((0,-π/4)), Gray(0.8)) == expected
 		img = zeros(Gray,3,3)
 		expected = copy(img)
-		@test draw(img, LineNormal(4,0)) == expected
-		@test draw(img, LineNormal(4,π/2)) == expected
-		@test draw(img, LineNormal(5,π/4)) == expected
+		@test @inferred draw(img, LineNormal(4,0)) == expected
+		@test @inferred draw(img, LineNormal(4,π/2)) == expected
+		@test @inferred draw(img, LineNormal(5,π/4)) == expected
 	end
 
 	@testset "LineTwoPoints" begin
 		img = zeros(Gray{N0f8}, 10, 10)
 		expected = copy(img)
 		expected[diagind(expected)] = one(Gray{N0f8})
-		res = draw(img, LineTwoPoints(1,1,10,10))
+		res = @inferred draw(img, LineTwoPoints(1,1,10,10))
 		@test expected == res
-		res = draw(img, LineTwoPoints(1,1,10,10), bresenham)
+		res = @inferred draw(img, LineTwoPoints(1,1,10,10), bresenham)
 		@test expected == res
-		res = draw(img, LineTwoPoints(1,1,10,10), one(Gray), bresenham)
+		res = @inferred draw(img, LineTwoPoints(1,1,10,10), one(Gray), bresenham)
 		@test expected == res
-		res = draw(img, LineTwoPoints(1,1,10,10), one(Gray))
+		res = @inferred draw(img, LineTwoPoints(1,1,10,10), one(Gray))
 		@test expected == res
-		res = draw(img, LineTwoPoints(CartesianIndex(1, 1), CartesianIndex(10, 10)))
+		res = @inferred draw(img, LineTwoPoints(CartesianIndex(1, 1), CartesianIndex(10, 10)))
 		@test expected == res
-		res = draw(img, LineTwoPoints(CartesianIndex(1, 1), CartesianIndex(10, 10)), bresenham)
+		res = @inferred draw(img, LineTwoPoints(CartesianIndex(1, 1), CartesianIndex(10, 10)), bresenham)
 		@test expected == res
-		res = draw(img, LineTwoPoints(CartesianIndex(1, 1), CartesianIndex(10, 10)), one(Gray), bresenham)
+		res = @inferred draw(img, LineTwoPoints(CartesianIndex(1, 1), CartesianIndex(10, 10)), one(Gray), bresenham)
 		@test expected == res
-		res = draw(img, LineTwoPoints(CartesianIndex(1, 1), CartesianIndex(10, 10)), one(Gray))
+		res = @inferred draw(img, LineTwoPoints(CartesianIndex(1, 1), CartesianIndex(10, 10)), one(Gray))
 		@test expected == res
 		expected[diagind(expected)] = Gray{N0f8}(0.5)
-		res = draw(img, LineTwoPoints(1,1,10,10), Gray{N0f8}(0.5))
+		res = @inferred draw(img, LineTwoPoints(1,1,10,10), Gray{N0f8}(0.5))
 		@test expected == res
 		img2 = zeros(RGB, 10, 10)
 		expected = copy(img2)
 		expected[diagind(expected)] = RGB{N0f8}(0.2, 0.3, 0.4)
-		res = draw(img2, LineTwoPoints(1,1,10,10), RGB{N0f8}(0.2,0.3,0.4))
+		res = @inferred draw(img2, LineTwoPoints(1,1,10,10), RGB{N0f8}(0.2,0.3,0.4))
 		@test expected == res
-		@test img2 == draw(img2, LineTwoPoints(1,11,10,11))
+		@test img2 == @inferred draw(img2, LineTwoPoints(1,11,10,11))
 	end
 end

--- a/test/paths.jl
+++ b/test/paths.jl
@@ -31,6 +31,14 @@ using Base.Test
     @test all(x->x==RGB{N0f8}(1,0,0), img[3,1:3])==true
     @test all(x->x==RGB{N0f8}(0,0,0), img[2,2:3])==true
     @test img[2,4]==RGB{N0f8}(1,0,0)
+
+    poly_tuples = [(1,1),(3,1),(5,1),(3,3),(1,3)]
+    img = draw(zeros(Gray{Bool},5,5), Polygon(poly_tuples))
+    @test all(x->x==true, img[1,:])==true
+    @test all(x->x==true, img[1:3,1])==true
+    @test all(x->x==true, img[3,1:3])==true
+    @test all(x->x==false, img[2,2:3])==true
+    @test img[2,4]==true
 end
 
 @testset "Path" begin
@@ -43,6 +51,15 @@ end
 
     img=zeros(RGB{N0f8},5,5)
     draw!(img, Path(vert))
+    @test all(x->x==RGB{N0f8}(1,1,1), img[1,:])==true
+    @test all(x->x==RGB{N0f8}(1,1,1), img[3,1:3])==true
+    @test all(x->x==RGB{N0f8}(0,0,0), img[2,1:3])==true
+    @test img[2,4]==RGB{N0f8}(1,1,1)
+
+    poly_tuples = [(1,1),(3,1),(5,1),(3,3),(1,3)]
+
+    img=zeros(RGB{N0f8},5,5)
+    draw!(img, Path(poly_tuples))
     @test all(x->x==RGB{N0f8}(1,1,1), img[1,:])==true
     @test all(x->x==RGB{N0f8}(1,1,1), img[3,1:3])==true
     @test all(x->x==RGB{N0f8}(0,0,0), img[2,1:3])==true

--- a/test/paths.jl
+++ b/test/paths.jl
@@ -1,7 +1,7 @@
 using ImageDraw, ColorTypes, FixedPointNumbers
 using Base.Test
 
-@testset "Paths" begin
+@testset "Polygon" begin
     vert=CartesianIndex{2}[]
     push!(vert, CartesianIndex(1,1))
     push!(vert, CartesianIndex(1,3))
@@ -9,7 +9,7 @@ using Base.Test
     push!(vert, CartesianIndex(3,3))
     push!(vert, CartesianIndex(3,1))
 
-    img = path(zeros(Gray{Bool},5,5), vert, closed=true)
+    img = draw(zeros(Gray{Bool},5,5), Polygon(vert))
     @test all(x->x==true, img[1,:])==true
     @test all(x->x==true, img[1:3,1])==true
     @test all(x->x==true, img[3,1:3])==true
@@ -17,7 +17,7 @@ using Base.Test
     @test img[2,4]==true
 
     img=zeros(Gray{Bool},5,5)
-    path!(img, vert)
+    draw!(img, Polygon(vert))
     @test all(x->x==true, img[1,:])==true
     @test all(x->x==true, img[1:3,1])==true
     @test all(x->x==true, img[3,1:3])==true
@@ -25,17 +25,36 @@ using Base.Test
     @test img[2,4]==true
 
     img=zeros(RGB{N0f8},5,5)
-    path!(img, vert, RGB{N0f8}(1,0,0), closed=true)
+    draw!(img, Polygon(vert), RGB(1,0,0))
     @test all(x->x==RGB{N0f8}(1,0,0), img[1,:])==true
     @test all(x->x==RGB{N0f8}(1,0,0), img[1:3,1])==true
     @test all(x->x==RGB{N0f8}(1,0,0), img[3,1:3])==true
     @test all(x->x==RGB{N0f8}(0,0,0), img[2,2:3])==true
     @test img[2,4]==RGB{N0f8}(1,0,0)
+end
+
+@testset "Path" begin
+    vert=CartesianIndex{2}[]
+    push!(vert, CartesianIndex(1,1))
+    push!(vert, CartesianIndex(1,3))
+    push!(vert, CartesianIndex(1,5))
+    push!(vert, CartesianIndex(3,3))
+    push!(vert, CartesianIndex(3,1))
 
     img=zeros(RGB{N0f8},5,5)
-    path!(img, vert,closed=false)
+    draw!(img, Path(vert))
     @test all(x->x==RGB{N0f8}(1,1,1), img[1,:])==true
     @test all(x->x==RGB{N0f8}(1,1,1), img[3,1:3])==true
     @test all(x->x==RGB{N0f8}(0,0,0), img[2,1:3])==true
     @test img[2,4]==RGB{N0f8}(1,1,1)
+end
+
+@testset "RegularPolygon" begin
+    img = zeros(Gray, 10, 10)
+    expected = copy(img)
+    expected[3, 2:6] = Gray(1)
+    expected[7, 2:6] = Gray(1)
+    expected[3:7, 2] = Gray(1)
+    expected[3:7, 6] = Gray(1)
+    @test all(expected .== draw(img, RegularPolygon(CartesianIndex(5,4), 4, 4, π/4))) == true
 end

--- a/test/paths.jl
+++ b/test/paths.jl
@@ -9,7 +9,7 @@ using Base.Test
     push!(vert, CartesianIndex(3,3))
     push!(vert, CartesianIndex(3,1))
 
-    img = draw(zeros(Gray{Bool},5,5), Polygon(vert))
+    img = @inferred draw(zeros(Gray{Bool},5,5), Polygon(vert))
     @test all(x->x==true, img[1,:])==true
     @test all(x->x==true, img[1:3,1])==true
     @test all(x->x==true, img[3,1:3])==true
@@ -17,7 +17,7 @@ using Base.Test
     @test img[2,4]==true
 
     img=zeros(Gray{Bool},5,5)
-    draw!(img, Polygon(vert))
+    @inferred draw!(img, Polygon(vert))
     @test all(x->x==true, img[1,:])==true
     @test all(x->x==true, img[1:3,1])==true
     @test all(x->x==true, img[3,1:3])==true
@@ -25,7 +25,7 @@ using Base.Test
     @test img[2,4]==true
 
     img=zeros(RGB{N0f8},5,5)
-    draw!(img, Polygon(vert), RGB(1,0,0))
+    @inferred draw!(img, Polygon(vert), RGB(1,0,0))
     @test all(x->x==RGB{N0f8}(1,0,0), img[1,:])==true
     @test all(x->x==RGB{N0f8}(1,0,0), img[1:3,1])==true
     @test all(x->x==RGB{N0f8}(1,0,0), img[3,1:3])==true
@@ -33,7 +33,7 @@ using Base.Test
     @test img[2,4]==RGB{N0f8}(1,0,0)
 
     poly_tuples = [(1,1),(3,1),(5,1),(3,3),(1,3)]
-    img = draw(zeros(Gray{Bool},5,5), Polygon(poly_tuples))
+    img = @inferred draw(zeros(Gray{Bool},5,5), Polygon(poly_tuples))
     @test all(x->x==true, img[1,:])==true
     @test all(x->x==true, img[1:3,1])==true
     @test all(x->x==true, img[3,1:3])==true
@@ -50,7 +50,7 @@ end
     push!(vert, CartesianIndex(3,1))
 
     img=zeros(RGB{N0f8},5,5)
-    draw!(img, Path(vert))
+    @inferred draw!(img, Path(vert))
     @test all(x->x==RGB{N0f8}(1,1,1), img[1,:])==true
     @test all(x->x==RGB{N0f8}(1,1,1), img[3,1:3])==true
     @test all(x->x==RGB{N0f8}(0,0,0), img[2,1:3])==true
@@ -59,11 +59,18 @@ end
     poly_tuples = [(1,1),(3,1),(5,1),(3,3),(1,3)]
 
     img=zeros(RGB{N0f8},5,5)
-    draw!(img, Path(poly_tuples))
+    @inferred draw!(img, Path(poly_tuples))
     @test all(x->x==RGB{N0f8}(1,1,1), img[1,:])==true
     @test all(x->x==RGB{N0f8}(1,1,1), img[3,1:3])==true
     @test all(x->x==RGB{N0f8}(0,0,0), img[2,1:3])==true
     @test img[2,4]==RGB{N0f8}(1,1,1)
+
+    img = zeros(Gray{N0f8},5,5)
+    invalid_points = [(6,1), (4,4), (1,7), (7,6)]
+    @test_throws ErrorException draw!(img, Path(invalid_points))
+
+    invalid_points = [(4,4), (1,7), (7,6)]
+    @test_throws ErrorException draw!(img, Path(invalid_points))
 end
 
 @testset "RegularPolygon" begin
@@ -73,5 +80,5 @@ end
     expected[7, 2:6] = Gray(1)
     expected[3:7, 2] = Gray(1)
     expected[3:7, 6] = Gray(1)
-    @test all(expected .== draw(img, RegularPolygon(CartesianIndex(5,4), 4, 4, π/4))) == true
+    @test all(expected .== @inferred draw(img, RegularPolygon(CartesianIndex(5,4), 4, 4, π/4))) == true
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,10 +3,11 @@ module ImageDrawTest
 using Base.Test, ImageDraw, ImageCore, ColorTypes, ColorVectorSpace, FixedPointNumbers
 
 tests = [
+    "core.jl",
     "line2d.jl",
     "ellipse2d.jl",
     "circle2d.jl",
-    "paths.jl",
+    "paths.jl"
 ]
 
 for t in tests


### PR DESCRIPTION
As mentioned in #11:
* All drawable objects are derived from `Drawable` abstract type.
* `draw!` (or `draw`) can be used to draw one or more `Drawable` objects on an image.
```
center = Point(200,200)
img = zeros(RGB, 400, 400)
imshow(draw(img, [CirclePointRadius(center, 50), center, LineNormal(150,0)], [RGB(1,0,0), RGB(0,0,1), RGB(1,0,1)]))
```
![img1](https://cloud.githubusercontent.com/assets/15063205/25004288/412a8b3e-2071-11e7-91ef-981cf8c06ce5.png)

Here we have two `Drawable` objects: `CirclePointRadius` and `Point`, that have been drawn on the image with different colours.

* Addition of `RegularPolygon <: Drawable` to draw a regular polygon on an image.
```
img = zeros(RGB, 400, 400)
square = RegularPolygon(Point(200,200), 4, 50, π/4)
triangle = RegularPolygon(Point(100,50), 3, 20, 0)
octagon = RegularPolygon(Point(200,200), 8, 50, π/4)
imshow(draw(img, [square, triangle, octagon], [RGB(0,1,0), RGB(0,0,1), RGB(1,0,0)]))
```
![img2](https://cloud.githubusercontent.com/assets/15063205/25004215/cc9fa2cc-2070-11e7-9039-e9365a8a6d4a.png)

* `Line` derived types have infinite length in contrast to `LineSegment` which are finite.
```
img = zeros(Gray, 400, 400)
l = LineTwoPoints(100, 100, 300, 300)
ls = LineSegment(300, 100, 100, 300)
imshow(draw(img, [l,ls]))
```
![img3](https://cloud.githubusercontent.com/assets/15063205/25004449/175ec300-2072-11e7-9c9f-152e42dfe0df.png)

* Some more `Drawable` types have been added like `CircleThreePoints`, `Path` and `Polygon`:
```
p1 = Point(200, 100); p2 = Point(100, 200); p3 = Point(300,200)
circle = CircleThreePoints(p1, p2, p3)
img = zeros(RGB, 400 ,400)
polygon = Polygon([p1,p2,p3])
imshow(draw(img, [circle, polygon, p1, p2, p3], [RGB(1,0,0), RGB(0,0,1)]))
```
![img4](https://cloud.githubusercontent.com/assets/15063205/25005997/d32c5010-2078-11e7-9114-91ebd58c47cf.png)
