### PR TITLE
Display ROI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.3"
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]

--- a/src/ImageDraw.jl
+++ b/src/ImageDraw.jl
@@ -1,7 +1,7 @@
 module ImageDraw
 
 # package code goes here
-using ImageCore, Distances
+using ImageCore, Distances, ImageTransformations
 
 include("core.jl")
 include("line2d.jl")
@@ -9,13 +9,15 @@ include("ellipse2d.jl")
 include("circle2d.jl")
 include("paths.jl")
 include("cross.jl")
+include("roi.jl")
 
 #export methods
 export
 	draw,
 	draw!,
 	bresenham,
-	xiaolin_wu
+	xiaolin_wu,
+	inset_roi
 
 #export types
 export

--- a/src/roi.jl
+++ b/src/roi.jl
@@ -1,0 +1,69 @@
+@enum AlignOptions begin
+    top_left = 1
+    top_right = 2
+    bottom_right = 3
+    bottom_left = 4
+end
+
+function inset_roi(
+    img::AbstractArray{T, 2},
+    roi::NTuple{2, NTuple{2, <:Int}},
+    scale::R,
+    align::AlignOptions,
+    color::C
+) where {T<:Colorant, R<:Real, C<:Colorant}
+
+    ((sx, sy), (ex, ey)) = roi
+
+    if !checkindex(Bool, axes(img, 1), sx) ||
+       !checkindex(Bool, axes(img, 1), ex) ||
+       !checkindex(Bool, axes(img, 2), sy) ||
+       !checkindex(Bool, axes(img, 2), ey)
+        throw(ArgumentError("Region of interest lies out of image"))
+    end
+
+    U = promote_type(T, C) # support different types natively
+    img = convert.(U, img) # copy
+    color = convert(U, color)
+
+    roi_image = @view img[sx:ex, sy:ey]
+    roi_image = imresize(roi_image; ratio=scale) # copy
+
+    if !all(size(roi_image) .<= size(img))
+        throw(ArgumentError("The scaled region of interest is larger than the image"))
+    end
+
+    border_rect = [
+        (first(axes(roi_image, 2)), first(axes(roi_image, 1))),
+        (last(axes(roi_image, 2)), first(axes(roi_image, 1))),
+        (last(axes(roi_image, 2)), last(axes(roi_image, 1))),
+        (first(axes(roi_image, 2)), last(axes(roi_image, 1))),
+    ]
+
+    draw!(roi_image, Polygon(border_rect), color)
+
+    roi_rect = [
+        (sy, sx),
+        (ey, sx),
+        (ey, ex),
+        (sy, ex)
+    ]
+    draw!(img, Polygon(roi_rect), color)
+
+    if align == top_left
+        img[first(axes(img, 1)):first(axes(img, 1))+size(roi_image, 1)-1,
+            first(axes(img, 2)):first(axes(img, 2))+size(roi_image, 2)-1] = roi_image
+    elseif align == top_right
+        img[first(axes(img, 1)):first(axes(img, 1))+size(roi_image, 1)-1,
+            last(axes(img, 2))-size(roi_image, 2)+1:last(axes(img, 2))] = roi_image
+    elseif align == bottom_right
+        img[last(axes(img, 1))-size(roi_image, 1)+1:last(axes(img, 1)),
+            last(axes(img, 2))-size(roi_image, 2)+1:last(axes(img, 2))] = roi_image
+    else
+        align == bottom_left
+        img[last(axes(img, 1))-size(roi_image, 1)+1:last(axes(img, 1)),
+            first(axes(img, 2)):first(axes(img, 2))+size(roi_image, 2)-1] = roi_image
+    end
+
+    return img
+end

--- a/src/roi.jl
+++ b/src/roi.jl
@@ -67,3 +67,24 @@ function inset_roi(
 
     return img
 end
+
+function display_roi(
+    img::AbstractArray{T, 2},
+    roi::AbstractVector{NTuple{2, NTuple{2, <:Int}}},
+    size::AbstractVector{<:Real},
+    align::AbstractVector{AlignOptions},
+    color::AbstractVector{C}
+) where {T<:Colorant, C<:Colorant}
+    if !(length(roi) == length(size) == length(color) == length(align))
+        throw(ArgumentError("Arrays roi, size, align and color must be of the same length, instead got $(length(roi)), $(length(size)), $(length(align)) and $(length(color))"))
+    end
+
+    if length(roi) > 4
+        throw(ArgumentError("Only upto 4 regions of interest can be displayed, instead got $(length(roi))"))
+    end
+
+    if length(unique(align)) < length(align)
+        @warn "Similarly aligned regions will likely overlap"
+    end
+
+end


### PR DESCRIPTION
## Adds the `display_roi` functionality.
Adds `inset_roi` that enlarges and displays a single ROI inside the image itself.

Some considerations:
- Does not follow the usual `x` (first coordinate) refers to columns and `y` (second coordinate) refers to rows convention, because ROIs are more likely to be interpreted in terms of pixel indices, I assumed. Hence also does not use `Point` to denote the diagonal points of the rectangle so as to avoid confusion. Let me know if I assumed wrong.
- Natively supports drawing borders with a different type of colorant, even though `draw` does not, because highlighting ROIs in color on gray images is fairly common.

The second commit e71f317 adds a function signature that could support showing up to 4 different ROIs inside the image along the 4 corners, let me know if something like that would be desirable.

## Example
![screenshot-julia](https://user-images.githubusercontent.com/43912285/87978255-c0dd2600-caed-11ea-8a1e-1d80dcfdaaf1.png)

```julia
using Images, ImageDraw, TestImages
img = testimage("cameraman")
inset_roi(img, ((170, 170), (200, 300)), 2, ImageDraw.bottom_left, RGB(0, 1, 1))
```

@johnnychen94 