### PR TITLE
add fill and thickness keywords to ellipse and circle

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -25,7 +25,7 @@ using FileIO # hide
 img = testimage("lighthouse")
 
 # Detect edges at different scales by adjusting the `spatial_scale` parameter.
-draw!(img, Ellipse(CirclePointRadius(350,200,100)))
+draw!(img, Ellipse(CirclePointRadius(350,200,100,0,true)))
 save("images/lighthouse_circle.png", img) # hide
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -25,7 +25,7 @@ using FileIO # hide
 img = testimage("lighthouse")
 
 # Detect edges at different scales by adjusting the `spatial_scale` parameter.
-draw!(img, Ellipse(CirclePointRadius(350,200,100,0,true)))
+draw!(img, Ellipse(CirclePointRadius(350,200,100)))
 save("images/lighthouse_circle.png", img) # hide
 ```
 
@@ -33,6 +33,17 @@ When displayed, these three images look like this:
 ```@raw html
 <img src="images/lighthouse_circle.png" width="512px" alt="edge detection demo 1 image" />
 <p>
+```
+
+Drawing a circle with a thickness
+
+```@example usage
+using TestImages, ImageDraw, ColorVectorSpace
+using FileIO # hide
+img = testimage("lighthouse")
+
+# With keyword argument fill = false, circle with given thickness is computed 
+draw!(img, Ellipse(CirclePointRadius(350, 200, 100; thickness = 75, fill = false)))
 ```
 
 Drawing a Cross.

--- a/src/circle2d.jl
+++ b/src/circle2d.jl
@@ -2,8 +2,8 @@ import LinearAlgebra: det
 
 #CirclePointRadius methods
 
-CirclePointRadius(x::Int, y::Int, ρ::T; thickness::Int = 0, fill::Bool = true) where {T<:Real} = CirclePointRadius(Point(x,y), ρ, thickness, fill)
-CirclePointRadius(p::CartesianIndex{2}, ρ::T; thickness::Int = 0, fill::Bool = true) where {T<:Real} = CirclePointRadius(Point(p), ρ, thickness, fill)
+CirclePointRadius(x::Int, y::Int, ρ::T; thickness::Int = 0, fill::Bool = true) where {T<:Real} = CirclePointRadius{T}(Point(x,y), ρ, thickness, fill)
+CirclePointRadius(p::CartesianIndex{2}, ρ::T; thickness::Int = 0, fill::Bool = true) where {T<:Real} = CirclePointRadius{T}(Point(p), ρ, thickness, fill)
 
 draw!(img::AbstractArray{T, 2}, circle::CirclePointRadius, color::T) where {T<:Colorant} = draw!(img, Ellipse(circle), color)
 

--- a/src/circle2d.jl
+++ b/src/circle2d.jl
@@ -1,9 +1,8 @@
 import LinearAlgebra: det
 
 #CirclePointRadius methods
-
-CirclePointRadius(x::Int, y::Int, ρ::T) where {T<:Real} = CirclePointRadius(Point(x,y), ρ)
-CirclePointRadius(p::CartesianIndex{2}, ρ::T) where {T<:Real} = CirclePointRadius(Point(p), ρ)
+CirclePointRadius(x::Int, y::Int, ρ::T,thickness::Int,fill::Bool) where {T<:Real} = CirclePointRadius(Point(x,y), ρ,thickness,fill)
+CirclePointRadius(p::CartesianIndex{2}, ρ::T,thickness::Int,fill::Bool) where {T<:Real} = CirclePointRadius(Point(p), ρ,thickness,fill)
 
 draw!(img::AbstractArray{T, 2}, circle::CirclePointRadius, color::T) where {T<:Colorant} = draw!(img, Ellipse(circle), color)
 

--- a/src/circle2d.jl
+++ b/src/circle2d.jl
@@ -24,5 +24,5 @@ function draw!(img::AbstractArray{T, 2}, circle::CircleThreePoints, color::T) wh
     ρ = euclidean([x1, y1], R)
     (first(ind[2]) <= R[1] <= last(ind[2]) && first(ind[1]) <= R[2] <= last(ind[1])) || error("Center of circle is out of the bounds of image")
     ρ - 1 <= minimum(abs, [R[1] - first(ind[2]), R[1] - last(ind[2]), R[2] - first(ind[1]), R[2] - last(ind[1])]) || error("Circle is out of the bounds of image : Radius is too large")
-    draw!(img, CirclePointRadius(Point(round(Int,R[1]), round(Int,R[2])), ρ), color)
+    draw!(img, CirclePointRadius(Point(round(Int,R[1]), round(Int,R[2])), ρ, 0, true), color)
 end

--- a/src/circle2d.jl
+++ b/src/circle2d.jl
@@ -1,8 +1,9 @@
 import LinearAlgebra: det
 
 #CirclePointRadius methods
-CirclePointRadius(x::Int, y::Int, ρ::T,thickness::Int,fill::Bool) where {T<:Real} = CirclePointRadius(Point(x,y), ρ,thickness,fill)
-CirclePointRadius(p::CartesianIndex{2}, ρ::T,thickness::Int,fill::Bool) where {T<:Real} = CirclePointRadius(Point(p), ρ,thickness,fill)
+
+CirclePointRadius(x::Int, y::Int, ρ::T; thickness::Int = 0, fill::Bool = true) where {T<:Real} = CirclePointRadius(Point(x,y), ρ, thickness, fill)
+CirclePointRadius(p::CartesianIndex{2}, ρ::T; thickness::Int = 0, fill::Bool = true) where {T<:Real} = CirclePointRadius(Point(p), ρ, thickness, fill)
 
 draw!(img::AbstractArray{T, 2}, circle::CirclePointRadius, color::T) where {T<:Colorant} = draw!(img, Ellipse(circle), color)
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -60,6 +60,8 @@ A `Drawable` circle having center `center` and radius `ρ`
 struct CirclePointRadius{T<:Real} <: Circle
     center::Point
     ρ::T
+    thickness::Int
+	fill::Bool
 end
 
 """
@@ -94,6 +96,8 @@ struct Ellipse{T<:Real, U<:Real} <: Drawable
     center::Point
     ρx::T
     ρy::U
+    thickness::Int
+	fill::Bool
 end
 
 """

--- a/src/core.jl
+++ b/src/core.jl
@@ -53,16 +53,36 @@ struct CircleThreePoints <: Circle
 end
 
 """
-    circle = CirclePointRadius(center, ρ)
+    circle = CirclePointRadius(center, ρ; thickness, fill)
 
 A `Drawable` circle having center `center` and radius `ρ`
+with keyword arguments `thickness` and `fill` for drawing hollow circle
+
+# Arguments
+- `thickness::Integer`: thickness of the circle 
+- `fill::Bool`: argument to determine whether to fill the circle or not
+
+# Examples
+```
+julia> using ImageDraw,TestImages,ImageView, ColorVectorSpace
+julia> img = testimage("lighthouse")
+
+julia> draw!(img, Ellipse(CirclePointRadius(350,200,100))) 
+julia> draw!(img, Ellipse(CirclePointRadius(150,200,100; thickness = 70 , fill = false)))
+
+julia> imshow(img)
+
+```
+
 """
 struct CirclePointRadius{T<:Real} <: Circle
     center::Point
     ρ::T
     thickness::Int
-	fill::Bool
+    fill::Bool
 end
+
+CirclePointRadius(center::Point, ρ::Real; thickness=1, fill=true) = CirclePointRadius(center, ρ, thickness, fill)
 
 """
     ls = LineSegment(p1, p2)
@@ -90,6 +110,7 @@ end
     ellipse = Ellipse(center, ρx, ρy)
 
 A `Drawable` ellipse with center `center` and parameters `ρx` and `ρy`
+with keyword arguments `thickness` and `fill` for drawing hollow ellipse
 
 """
 struct Ellipse{T<:Real, U<:Real} <: Drawable
@@ -97,8 +118,10 @@ struct Ellipse{T<:Real, U<:Real} <: Drawable
     ρx::T
     ρy::U
     thickness::Int
-	fill::Bool
+    fill::Bool
 end
+
+Ellipse(center::Point, ρx::T, ρy::U; thickness::Int =  0, fill::Bool = true) where {T<:Real, U<:Real} = Ellipse(center, ρx, ρy, thickness, fill)
 
 """
     polygon = Polygon([vertex])

--- a/src/core.jl
+++ b/src/core.jl
@@ -53,7 +53,7 @@ struct CircleThreePoints <: Circle
 end
 
 """
-    circle = CirclePointRadius(center, ρ; thickness, fill)
+    circle = CirclePointRadius(center, ρ; thickness = 0, fill = false)
 
 A `Drawable` circle having center `center` and radius `ρ`
 with keyword arguments `thickness` and `fill` for drawing hollow circle
@@ -64,14 +64,11 @@ with keyword arguments `thickness` and `fill` for drawing hollow circle
 
 # Examples
 ```
-julia> using ImageDraw,TestImages,ImageView, ColorVectorSpace
-julia> img = testimage("lighthouse")
+using ImageDraw,TestImages,ImageView, ColorVectorSpace
+img = testimage("lighthouse")
 
-julia> draw!(img, Ellipse(CirclePointRadius(350,200,100))) 
-julia> draw!(img, Ellipse(CirclePointRadius(150,200,100; thickness = 70 , fill = false)))
-
-julia> imshow(img)
-
+draw!(img, Ellipse(CirclePointRadius(350,200,100))) 
+draw!(img, Ellipse(CirclePointRadius(150,200,100; thickness = 70 , fill = false)))
 ```
 
 """
@@ -80,9 +77,14 @@ struct CirclePointRadius{T<:Real} <: Circle
     ρ::T
     thickness::Int
     fill::Bool
+    function CirclePointRadius{T}(center::Point, ρ::T, thickness::Int = 0, fill::Bool = true) where {T<:Real}
+        thickness >= ρ && throw(ArgumentError("Thickness $thickness should be smaller than $(ρ)."))
+        new{T}(center, ρ, thickness, fill)
+    end
 end
 
-CirclePointRadius(center::Point, ρ::Real; thickness=1, fill=true) = CirclePointRadius(center, ρ, thickness, fill)
+CirclePointRadius(center::Point, ρ::T; thickness::Int = 0, fill::Bool = true) where {T<:Real} = CirclePointRadius{T}(center, ρ, thickness, fill)
+CirclePointRadius(center::Point, ρ::T, thickness::Int = 0, fill::Bool = true) where {T<:Real} = CirclePointRadius{T}(center, ρ, thickness, fill)
 
 """
     ls = LineSegment(p1, p2)
@@ -107,23 +109,42 @@ struct Path <: Drawable
 end
 
 """
-    ellipse = Ellipse(center, ρx, ρy)
+    ellipse = Ellipse(center, ρx, ρy; thickness = 0,fill = false)
 
 A `Drawable` ellipse with center `center` and parameters `ρx` and `ρy`
 with keyword arguments `thickness` and `fill` for drawing hollow ellipse
 
+# Arguments
+- `thickness::Integer`: thickness of the ellipse
+- `fill::Bool`: argument to determine whether to fill the ellipse or not
+
+# Examples
+```
+using ImageDraw,TestImages,ImageView, ColorVectorSpace
+img = testimage("lighthouse")
+
+draw(img, Ellipse(5, 5, 5, 5), Gray{N0f8}(0.5))
+draw(img, Ellipse(CartesianIndex(5,5), 5, 3))
+draw(img, Ellipse(CirclePointRadius(Point(6, 6), 5; thickness = 4, fill = false)))
+```
 """
+
 struct Ellipse{T<:Real, U<:Real} <: Drawable
     center::Point
     ρx::T
     ρy::U
     thickness::Int
     fill::Bool
+    function Ellipse{T, U}(center, ρx::T, ρy::U, thickness::Int = 0, fill::Bool = true) where {T<:Real, U<:Real}
+        thickness >= min(ρx, ρy) && throw(ArgumentError("Thickness $thickness should be smaller than $(min(ρx, ρy))."))
+        new{T, U}(center, ρx, ρy, thickness, fill)
+    end
 end
 
-Ellipse(center::Point, ρx::T, ρy::U; thickness::Int =  0, fill::Bool = true) where {T<:Real, U<:Real} = Ellipse(center, ρx, ρy, thickness, fill)
+Ellipse(center::Point, ρx::T, ρy::U; thickness::Int = 0, fill::Bool = true) where {T<:Real, U<:Real} = Ellipse{T,U}(center, ρx, ρy, thickness, fill)
+Ellipse(center::Point, ρx::T, ρy::U, thickness::Int = 0, fill::Bool = true) where {T<:Real, U<:Real} = Ellipse{T,U}(center, ρx, ρy, thickness, fill)
 
-"""
+""" 
     polygon = Polygon([vertex])
 
 A `Drawable` polygon i.e. a closed path created by joining the

--- a/src/core.jl
+++ b/src/core.jl
@@ -60,7 +60,7 @@ A `Drawable` circle having center `center` and radius `ρ`
 with keyword arguments `thickness` and `fill` for drawing hollow circle
 
 # Arguments
-- `thickness::Integer`: thickness of the circle 
+- `thickness::Int`: thickness of the circle
 - `fill::Bool`: argument to determine whether to fill the circle or not
 
 # Examples
@@ -116,7 +116,7 @@ A `Drawable` ellipse with center `center` and parameters `ρx` and `ρy`
 with keyword arguments `thickness` and `fill` for drawing hollow ellipse
 
 # Arguments
-- `thickness::Integer`: thickness of the ellipse
+- `thickness::Int`: thickness of the circle
 - `fill::Bool`: argument to determine whether to fill the ellipse or not
 
 # Examples

--- a/src/ellipse2d.jl
+++ b/src/ellipse2d.jl
@@ -9,7 +9,7 @@ function draw!(img::AbstractArray{T, 2}, ellipse::Ellipse, color::T) where T<:Co
 	xs = Int[]
 	break_point = 0
 	if ellipse.fill == false
-        break_point = ((ellipse.ρy - ellipse.thickness)/ ellipse.ρy) ^ 2 + ((ellipse.ρx - ellipse.thickness)/ ellipse.ρx) ^ 2 
+		break_point = ((ellipse.ρy - ellipse.thickness) / ellipse.ρy) ^ 2 + ((ellipse.ρx - ellipse.thickness) / ellipse.ρx) ^ 2 
 	end
 	for i in ellipse.center.y : ellipse.center.y + ellipse.ρy
 		for j in ellipse.center.x : ellipse.center.x + ellipse.ρx

--- a/src/ellipse2d.jl
+++ b/src/ellipse2d.jl
@@ -1,16 +1,13 @@
 #Ellipse methods
 
-Ellipse(x::Int, y::Int, ρx::T, ρy::U; thickness::Int =  0, fill::Bool = true) where {T<:Real, U<:Real} = Ellipse(Point(x,y), ρx, ρy, thickness, fill)
-Ellipse(p::CartesianIndex{2}, ρx::T, ρy::U; thickness::Int = 0, fill::Bool = true) where {T<:Real, U<:Real} = Ellipse(Point(p), ρx, ρy, thickness, fill)
-Ellipse(circle::CirclePointRadius) = Ellipse(circle.center, circle.ρ, circle.ρ, circle.thickness, circle.fill)
+Ellipse(x::Int, y::Int, ρx::T, ρy::U; thickness::Int = 0, fill::Bool = true) where {T<:Real, U<:Real} = Ellipse{T, U}(Point(x,y), ρx, ρy, thickness, fill)
+Ellipse(p::CartesianIndex{2}, ρx::T, ρy::U; thickness::Int = 0, fill::Bool = true) where {T<:Real, U<:Real} = Ellipse{T, U}(Point(p), ρx, ρy, thickness, fill)
+Ellipse(circle::CirclePointRadius) = Ellipse(circle.center, circle.ρ, circle.ρ;  thickness = circle.thickness, fill = circle.fill)
 
 function draw!(img::AbstractArray{T, 2}, ellipse::Ellipse, color::T) where T<:Colorant
 	ys = Int[]
 	xs = Int[]
 	break_point = 0
-    if ellipse.thickness >= ellipse.ρy || ellipse.thickness >= ellipse.ρx
-		error("Thickness greater than a,b not allowed")
-	end
 	if ellipse.fill == false
         break_point = ((ellipse.ρy - ellipse.thickness)/ ellipse.ρy) ^ 2 + ((ellipse.ρx - ellipse.thickness)/ ellipse.ρx) ^ 2 
 	end

--- a/src/ellipse2d.jl
+++ b/src/ellipse2d.jl
@@ -1,7 +1,7 @@
 #Ellipse methods
 
-Ellipse(x::Int, y::Int, ρx::T, ρy::U) where {T<:Real, U<:Real} = Ellipse(Point(x,y), ρx, ρy)
-Ellipse(p::CartesianIndex{2}, ρx::T, ρy::U) where {T<:Real, U<:Real} = Ellipse(Point(p), ρx, ρy)
+Ellipse(x::Int, y::Int, ρx::T, ρy::U , thickness::Int ,fill::Bool) where {T<:Real, U<:Real} = Ellipse(Point(x,y), ρx, ρy, thickness,fill)
+Ellipse(p::CartesianIndex{2}, ρx::T, ρy::U, thickness::Int ,fill::Bool) where {T<:Real, U<:Real} = Ellipse(Point(p), ρx, ρy,thickness,fill)
 Ellipse(circle::CirclePointRadius) = Ellipse(circle.center, circle.ρ, circle.ρ,circle.thickness,circle.fill)
 
 function draw!(img::AbstractArray{T, 2}, ellipse::Ellipse, color::T) where T<:Colorant
@@ -17,7 +17,7 @@ function draw!(img::AbstractArray{T, 2}, ellipse::Ellipse, color::T) where T<:Co
 	for i in ellipse.center.y : ellipse.center.y + ellipse.ρy
 		for j in ellipse.center.x : ellipse.center.x + ellipse.ρx
 			val = ((i - ellipse.center.y) / ellipse.ρy) ^ 2 + ((j - ellipse.center.x) / ellipse.ρx) ^ 2
-			if val < 1 && val > break_point
+			if val < 1 && val >= break_point			
 				push!(ys, i)
 				push!(xs, j)
 			end

--- a/src/ellipse2d.jl
+++ b/src/ellipse2d.jl
@@ -2,15 +2,22 @@
 
 Ellipse(x::Int, y::Int, ρx::T, ρy::U) where {T<:Real, U<:Real} = Ellipse(Point(x,y), ρx, ρy)
 Ellipse(p::CartesianIndex{2}, ρx::T, ρy::U) where {T<:Real, U<:Real} = Ellipse(Point(p), ρx, ρy)
-Ellipse(circle::CirclePointRadius) = Ellipse(circle.center, circle.ρ, circle.ρ)
+Ellipse(circle::CirclePointRadius) = Ellipse(circle.center, circle.ρ, circle.ρ,circle.thickness,circle.fill)
 
 function draw!(img::AbstractArray{T, 2}, ellipse::Ellipse, color::T) where T<:Colorant
 	ys = Int[]
 	xs = Int[]
+	break_point = 0
+    if ellipse.thickness >= ellipse.ρy || ellipse.thickness >= ellipse.ρx
+			error("Thickness greater than a,b not allowed")
+	end
+	if ellipse.fill == false
+        break_point = ((ellipse.ρy - ellipse.thickness)/ ellipse.ρy) ^ 2 + ((ellipse.ρx - ellipse.thickness)/ ellipse.ρx) ^2 
+	end
 	for i in ellipse.center.y : ellipse.center.y + ellipse.ρy
 		for j in ellipse.center.x : ellipse.center.x + ellipse.ρx
 			val = ((i - ellipse.center.y) / ellipse.ρy) ^ 2 + ((j - ellipse.center.x) / ellipse.ρx) ^ 2
-			if val < 1
+			if val < 1 && val > break_point
 				push!(ys, i)
 				push!(xs, j)
 			end

--- a/src/ellipse2d.jl
+++ b/src/ellipse2d.jl
@@ -1,18 +1,18 @@
 #Ellipse methods
 
-Ellipse(x::Int, y::Int, ρx::T, ρy::U , thickness::Int ,fill::Bool) where {T<:Real, U<:Real} = Ellipse(Point(x,y), ρx, ρy, thickness,fill)
-Ellipse(p::CartesianIndex{2}, ρx::T, ρy::U, thickness::Int ,fill::Bool) where {T<:Real, U<:Real} = Ellipse(Point(p), ρx, ρy,thickness,fill)
-Ellipse(circle::CirclePointRadius) = Ellipse(circle.center, circle.ρ, circle.ρ,circle.thickness,circle.fill)
+Ellipse(x::Int, y::Int, ρx::T, ρy::U; thickness::Int =  0, fill::Bool = true) where {T<:Real, U<:Real} = Ellipse(Point(x,y), ρx, ρy, thickness, fill)
+Ellipse(p::CartesianIndex{2}, ρx::T, ρy::U; thickness::Int = 0, fill::Bool = true) where {T<:Real, U<:Real} = Ellipse(Point(p), ρx, ρy, thickness, fill)
+Ellipse(circle::CirclePointRadius) = Ellipse(circle.center, circle.ρ, circle.ρ, circle.thickness, circle.fill)
 
 function draw!(img::AbstractArray{T, 2}, ellipse::Ellipse, color::T) where T<:Colorant
 	ys = Int[]
 	xs = Int[]
 	break_point = 0
     if ellipse.thickness >= ellipse.ρy || ellipse.thickness >= ellipse.ρx
-			error("Thickness greater than a,b not allowed")
+		error("Thickness greater than a,b not allowed")
 	end
 	if ellipse.fill == false
-        break_point = ((ellipse.ρy - ellipse.thickness)/ ellipse.ρy) ^ 2 + ((ellipse.ρx - ellipse.thickness)/ ellipse.ρx) ^2 
+        break_point = ((ellipse.ρy - ellipse.thickness)/ ellipse.ρy) ^ 2 + ((ellipse.ρx - ellipse.thickness)/ ellipse.ρx) ^ 2 
 	end
 	for i in ellipse.center.y : ellipse.center.y + ellipse.ρy
 		for j in ellipse.center.x : ellipse.center.x + ellipse.ρx

--- a/test/circle2d.jl
+++ b/test/circle2d.jl
@@ -48,6 +48,12 @@ using LinearAlgebra
         err = ArgumentError("Thickness 7 should be smaller than 5.")
         @test_throws err CirclePointRadius(CartesianIndex(6, 6), 5; thickness = 7, fill = false)
 
+        @test draw(img, CirclePointRadius(Point(6, 6), 5; thickness = 0, fill = true)) == draw(img, CirclePointRadius(Point(6, 6), 5))
+
+        @test draw(img, CirclePointRadius(CartesianIndex(5,5), 5; thickness = 0, fill = true)) == draw(img, CirclePointRadius(CartesianIndex(5,5), 5))
+        
+        @test draw(img, CirclePointRadius(5, 5, 5; thickness = 0, fill = true)) == draw(img, CirclePointRadius(5, 5, 5))
+
         # expected = CirclePointRadius(Point(6, 6), 5; thickness=UInt8(1), fill=false)
         # res = CirclePointRadius(Point(6, 6), 5; thickness=1, fill=false)
         # @test expected == res

--- a/test/circle2d.jl
+++ b/test/circle2d.jl
@@ -15,16 +15,16 @@ using LinearAlgebra
                                 0 0 1 1 1 1 1 0 0 0
                                 0 0 0 0 0 0 0 0 0 0 ]
 
-        res = @inferred draw(img, CirclePointRadius(Point(5,5), 5))
+        res = @inferred draw(img, CirclePointRadius(Point(5,5), 5, 0, true))
         @test all(expected .== res) == true
 
-        res = @inferred draw(img, CirclePointRadius(5, 5, 5))
+        res = @inferred draw(img, CirclePointRadius(5, 5, 5, 0, true))
         @test all(expected .== res) == true
 
-        res = @inferred draw(img, CirclePointRadius(CartesianIndex(5,5), 5))
+        res = @inferred draw(img, CirclePointRadius(CartesianIndex(5,5), 5, 0, true))
         @test all(expected .== res) == true
 
-        res = @inferred draw(img, CirclePointRadius(Point(5,5), 5), Gray{N0f8}(0.5))
+        res = @inferred draw(img, CirclePointRadius(Point(5,5), 5, 0, true), Gray{N0f8}(0.5))
         expected = map(i->(i==1 ? Gray{N0f8}(0.5) : Gray{N0f8}(0)), expected)
         @test all(expected .== res) == true
 

--- a/test/circle2d.jl
+++ b/test/circle2d.jl
@@ -40,8 +40,17 @@ using LinearAlgebra
                                0 0 1 1 1 1 1 1 1 0
                                0 0 0 1 1 1 1 1 0 0 ]
 
-        res = @inferred draw(img, CirclePointRadius(Point(6, 6), 5, 3, false))
+        res = @inferred draw(img, CirclePointRadius(Point(6, 6), 5; thickness = 3, fill = false))
         @test all(expected .== res)
+
+        @test CirclePointRadius(Point(6, 6), 5, 3, false) == CirclePointRadius(Point(6, 6), 5; thickness = 3, fill = false)
+        
+        err = ArgumentError("Thickness 7 should be smaller than 5.")
+        @test_throws err CirclePointRadius(CartesianIndex(6, 6), 5; thickness = 7, fill = false)
+
+        # expected = CirclePointRadius(Point(6, 6), 5; thickness=UInt8(1), fill=false)
+        # res = CirclePointRadius(Point(6, 6), 5; thickness=1, fill=false)
+        # @test expected == res
     end
 
     @testset "CircleThreePoints" begin

--- a/test/circle2d.jl
+++ b/test/circle2d.jl
@@ -15,19 +15,33 @@ using LinearAlgebra
                                 0 0 1 1 1 1 1 0 0 0
                                 0 0 0 0 0 0 0 0 0 0 ]
 
-        res = @inferred draw(img, CirclePointRadius(Point(5,5), 5, 0, true))
+        res = @inferred draw(img, CirclePointRadius(Point(5,5), 5))
         @test all(expected .== res) == true
 
-        res = @inferred draw(img, CirclePointRadius(5, 5, 5, 0, true))
+        res = @inferred draw(img, CirclePointRadius(5, 5, 5))
         @test all(expected .== res) == true
 
-        res = @inferred draw(img, CirclePointRadius(CartesianIndex(5,5), 5, 0, true))
+        res = @inferred draw(img, CirclePointRadius(CartesianIndex(5,5), 5))
         @test all(expected .== res) == true
 
-        res = @inferred draw(img, CirclePointRadius(Point(5,5), 5, 0, true), Gray{N0f8}(0.5))
+        res = @inferred draw(img, CirclePointRadius(Point(5,5), 5), Gray{N0f8}(0.5))
         expected = map(i->(i==1 ? Gray{N0f8}(0.5) : Gray{N0f8}(0)), expected)
         @test all(expected .== res) == true
 
+        img = zeros(Gray{N0f8}, 10, 10)
+        expected = Gray{N0f8}[ 0 0 0 0 0 0 0 0 0 0
+                               0 0 0 1 1 1 1 1 0 0
+                               0 0 1 1 1 1 1 1 1 0
+                               0 1 1 1 0 0 0 1 1 1
+                               0 1 1 0 0 0 0 0 1 1
+                               0 1 1 0 0 0 0 0 1 1
+                               0 1 1 0 0 0 0 0 1 1
+                               0 1 1 1 0 0 0 1 1 1
+                               0 0 1 1 1 1 1 1 1 0
+                               0 0 0 1 1 1 1 1 0 0 ]
+
+        res = @inferred draw(img, CirclePointRadius(Point(6, 6), 5, 3, false))
+        @test all(expected .== res)
     end
 
     @testset "CircleThreePoints" begin

--- a/test/ellipse2d.jl
+++ b/test/ellipse2d.jl
@@ -2,11 +2,11 @@
 
     img = zeros(Gray{N0f8}, 10, 10)
     expected = copy(img)
-    res = @inferred draw(img, Ellipse(Point(5,5), 5, 1))
+    res = @inferred draw(img, Ellipse(Point(5,5), 5, 1, 0, true))
     expected[5, 1:9] .= 1
     @test all(expected .== res) == true
 
-    res = @inferred draw(img, Ellipse(5, 5, 5, 5), oneunit(Gray{N0f8}))
+    res = @inferred draw(img, Ellipse(5, 5, 5, 5, 0, true), oneunit(Gray{N0f8}))
     expected = Gray{N0f8}[  0 0 1 1 1 1 1 0 0 0
                             0 1 1 1 1 1 1 1 0 0
                             1 1 1 1 1 1 1 1 1 0
@@ -19,14 +19,14 @@
                             0 0 0 0 0 0 0 0 0 0 ]
     @test all(expected .== res) == true
 
-    res = @inferred draw(img, Ellipse(CirclePointRadius(5,5,5)))
+    res = @inferred draw(img, Ellipse(CirclePointRadius(5, 5, 5, 1, true)))
     @test all(expected .== res) == true
 
-    res = @inferred draw(img, Ellipse(5, 5, 5, 5), Gray{N0f8}(0.5))
+    res = @inferred draw(img, Ellipse(5, 5, 5, 5 , 0, true), Gray{N0f8}(0.5))
     expected = map(i->(i==1 ? Gray{N0f8}(0.5) : Gray{N0f8}(0)), expected)
     @test all(expected .== res) == true
 
-    res = @inferred draw(img, Ellipse(CartesianIndex(5,5), 5, 3))
+    res = @inferred draw(img, Ellipse(CartesianIndex(5,5), 5, 3, 0, true))
     expected = Gray{N0f8}[  0 0 0 0 0 0 0 0 0 0
                             0 0 0 0 0 0 0 0 0 0
                             0 1 1 1 1 1 1 1 0 0

--- a/test/ellipse2d.jl
+++ b/test/ellipse2d.jl
@@ -2,11 +2,11 @@
 
     img = zeros(Gray{N0f8}, 10, 10)
     expected = copy(img)
-    res = @inferred draw(img, Ellipse(Point(5,5), 5, 1, 0, true))
+    res = @inferred draw(img, Ellipse(Point(5,5), 5, 1))
     expected[5, 1:9] .= 1
     @test all(expected .== res) == true
 
-    res = @inferred draw(img, Ellipse(5, 5, 5, 5, 0, true), oneunit(Gray{N0f8}))
+    res = @inferred draw(img, Ellipse(5, 5, 5, 5), oneunit(Gray{N0f8}))
     expected = Gray{N0f8}[  0 0 1 1 1 1 1 0 0 0
                             0 1 1 1 1 1 1 1 0 0
                             1 1 1 1 1 1 1 1 1 0
@@ -19,14 +19,14 @@
                             0 0 0 0 0 0 0 0 0 0 ]
     @test all(expected .== res) == true
 
-    res = @inferred draw(img, Ellipse(CirclePointRadius(5, 5, 5, 1, true)))
+    res = @inferred draw(img, Ellipse(CirclePointRadius(5, 5, 5)))
     @test all(expected .== res) == true
 
-    res = @inferred draw(img, Ellipse(5, 5, 5, 5 , 0, true), Gray{N0f8}(0.5))
+    res = @inferred draw(img, Ellipse(5, 5, 5, 5), Gray{N0f8}(0.5))
     expected = map(i->(i==1 ? Gray{N0f8}(0.5) : Gray{N0f8}(0)), expected)
     @test all(expected .== res) == true
 
-    res = @inferred draw(img, Ellipse(CartesianIndex(5,5), 5, 3, 0, true))
+    res = @inferred draw(img, Ellipse(CartesianIndex(5,5), 5, 3))
     expected = Gray{N0f8}[  0 0 0 0 0 0 0 0 0 0
                             0 0 0 0 0 0 0 0 0 0
                             0 1 1 1 1 1 1 1 0 0
@@ -38,4 +38,18 @@
                             0 0 0 0 0 0 0 0 0 0
                             0 0 0 0 0 0 0 0 0 0 ]
     @test all(expected .== res) == true
+    
+    img = zeros(Gray{N0f8}, 10, 10)
+    expected = Gray{N0f8}[ 0 0 0 0 0 0 0 0 0 0
+                           0 0 0 1 1 1 1 1 0 0
+                           0 0 1 1 1 1 1 1 1 0
+                           0 1 1 1 1 1 1 1 1 1
+                           0 1 1 1 1 0 1 1 1 1
+                           0 1 1 1 0 0 0 1 1 1
+                           0 1 1 1 1 0 1 1 1 1
+                           0 1 1 1 1 1 1 1 1 1
+                           0 0 1 1 1 1 1 1 1 0
+                           0 0 0 1 1 1 1 1 0 0 ]
+    res = @inferred draw(img, Ellipse(CirclePointRadius(Point(6, 6), 5, 4, false)))
+    @test all(expected .== res)
 end

--- a/test/ellipse2d.jl
+++ b/test/ellipse2d.jl
@@ -18,7 +18,7 @@
                             0 0 1 1 1 1 1 0 0 0
                             0 0 0 0 0 0 0 0 0 0 ]
     @test all(expected .== res) == true
-
+    
     res = @inferred draw(img, Ellipse(CirclePointRadius(5, 5, 5)))
     @test all(expected .== res) == true
 
@@ -50,6 +50,12 @@
                            0 1 1 1 1 1 1 1 1 1
                            0 0 1 1 1 1 1 1 1 0
                            0 0 0 1 1 1 1 1 0 0 ]
-    res = @inferred draw(img, Ellipse(CirclePointRadius(Point(6, 6), 5, 4, false)))
+    res = @inferred draw(img, Ellipse(CirclePointRadius(Point(6, 6), 5; thickness = 4, fill = false)))
     @test all(expected .== res)
+
+
+    @test Ellipse(Point(6, 6), 5, 5, 3, false) == Ellipse(Point(6, 6), 5, 5; thickness = 3, fill = false)
+        
+    err = ArgumentError("Thickness 7 should be smaller than 5.")
+    @test_throws err Ellipse(CartesianIndex(6, 6), 5, 5; thickness = 7, fill = false)
 end


### PR DESCRIPTION
I only made changes for circle case which is made through ellipse drawing methods due to the way the loops work...it had me all confused regarding the thickness and how we will calculate it.Though I am not entirely sure if the math in current case is completely right either too but it works just fine for a Initial PR
- Need to add thickness and dims keywords for CircleThree Points,Ellipse(this one got me really confused)

- [x] supposed to fix #50 