### PR TITLE
only expose thickness and fill as keyword

### DIFF
--- a/src/circle2d.jl
+++ b/src/circle2d.jl
@@ -25,5 +25,5 @@ function draw!(img::AbstractArray{T, 2}, circle::CircleThreePoints, color::T) wh
     ρ = euclidean([x1, y1], R)
     (first(ind[2]) <= R[1] <= last(ind[2]) && first(ind[1]) <= R[2] <= last(ind[1])) || error("Center of circle is out of the bounds of image")
     ρ - 1 <= minimum(abs, [R[1] - first(ind[2]), R[1] - last(ind[2]), R[2] - first(ind[1]), R[2] - last(ind[1])]) || error("Circle is out of the bounds of image : Radius is too large")
-    draw!(img, CirclePointRadius(Point(round(Int,R[1]), round(Int,R[2])), ρ; thickness=0, fill=true), color)
+    draw!(img, CirclePointRadius(Point(round(Int,R[1]), round(Int,R[2])), ρ), color)
 end

--- a/src/circle2d.jl
+++ b/src/circle2d.jl
@@ -2,8 +2,8 @@ import LinearAlgebra: det
 
 #CirclePointRadius methods
 
-CirclePointRadius(x::Int, y::Int, ρ::T; thickness::Int = 0, fill::Bool = true) where {T<:Real} = CirclePointRadius{T}(Point(x,y), ρ, thickness, fill)
-CirclePointRadius(p::CartesianIndex{2}, ρ::T; thickness::Int = 0, fill::Bool = true) where {T<:Real} = CirclePointRadius{T}(Point(p), ρ, thickness, fill)
+CirclePointRadius(x::Int, y::Int, args...; kwargs...) = CirclePointRadius(Point(x,y), args...; kwargs...)
+CirclePointRadius(p::CartesianIndex{2}, args...; kwargs...) = CirclePointRadius(Point(p), args...; kwargs...)
 
 draw!(img::AbstractArray{T, 2}, circle::CirclePointRadius, color::T) where {T<:Colorant} = draw!(img, Ellipse(circle), color)
 
@@ -25,5 +25,5 @@ function draw!(img::AbstractArray{T, 2}, circle::CircleThreePoints, color::T) wh
     ρ = euclidean([x1, y1], R)
     (first(ind[2]) <= R[1] <= last(ind[2]) && first(ind[1]) <= R[2] <= last(ind[1])) || error("Center of circle is out of the bounds of image")
     ρ - 1 <= minimum(abs, [R[1] - first(ind[2]), R[1] - last(ind[2]), R[2] - first(ind[1]), R[2] - last(ind[1])]) || error("Circle is out of the bounds of image : Radius is too large")
-    draw!(img, CirclePointRadius(Point(round(Int,R[1]), round(Int,R[2])), ρ, 0, true), color)
+    draw!(img, CirclePointRadius(Point(round(Int,R[1]), round(Int,R[2])), ρ; thickness=0, fill=true), color)
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -78,14 +78,13 @@ struct CirclePointRadius{T<:Real} <: Circle
     ρ::T
     thickness::Int
     fill::Bool
-    function CirclePointRadius{T}(center::Point, ρ::T, thickness::Int = 0, fill::Bool = true) where {T<:Real}
+    function CirclePointRadius{T}(center::Point, ρ::T; thickness::Int = 0, fill::Bool = true) where {T<:Real}
         thickness >= ρ && throw(ArgumentError("Thickness $thickness should be smaller than $(ρ)."))
         new{T}(center, ρ, thickness, fill)
     end
 end
 
-CirclePointRadius(center::Point, ρ::T; thickness::Int = 0, fill::Bool = true) where {T<:Real} = CirclePointRadius{T}(center, ρ, thickness, fill)
-CirclePointRadius(center::Point, ρ::T, thickness::Int = 0, fill::Bool = true) where {T<:Real} = CirclePointRadius{T}(center, ρ, thickness, fill)
+CirclePointRadius(center::Point, ρ::T; kwargs...) where {T<:Real} = CirclePointRadius{T}(center, ρ; kwargs...)
 
 """
     ls = LineSegment(p1, p2)
@@ -136,14 +135,13 @@ struct Ellipse{T<:Real, U<:Real} <: Drawable
     ρy::U
     thickness::Int
     fill::Bool
-    function Ellipse{T, U}(center, ρx::T, ρy::U, thickness::Int = 0, fill::Bool = true) where {T<:Real, U<:Real}
+    function Ellipse{T, U}(center, ρx::T, ρy::U; thickness::Int = 0, fill::Bool = true) where {T<:Real, U<:Real}
         thickness >= min(ρx, ρy) && throw(ArgumentError("Thickness $thickness should be smaller than $(min(ρx, ρy))."))
         new{T, U}(center, ρx, ρy, thickness, fill)
     end
 end
 
-Ellipse(center::Point, ρx::T, ρy::U; thickness::Int = 0, fill::Bool = true) where {T<:Real, U<:Real} = Ellipse{T,U}(center, ρx, ρy, thickness, fill)
-Ellipse(center::Point, ρx::T, ρy::U, thickness::Int = 0, fill::Bool = true) where {T<:Real, U<:Real} = Ellipse{T,U}(center, ρx, ρy, thickness, fill)
+Ellipse(center::Point, ρx::T, ρy::U; kwargs...) where {T<:Real, U<:Real} = Ellipse{T,U}(center, ρx, ρy; kwargs...)
 
 """ 
     polygon = Polygon([vertex])

--- a/src/ellipse2d.jl
+++ b/src/ellipse2d.jl
@@ -1,8 +1,8 @@
 #Ellipse methods
 
-Ellipse(x::Int, y::Int, ρx::T, ρy::U; thickness::Int = 0, fill::Bool = true) where {T<:Real, U<:Real} = Ellipse{T, U}(Point(x,y), ρx, ρy, thickness, fill)
-Ellipse(p::CartesianIndex{2}, ρx::T, ρy::U; thickness::Int = 0, fill::Bool = true) where {T<:Real, U<:Real} = Ellipse{T, U}(Point(p), ρx, ρy, thickness, fill)
-Ellipse(circle::CirclePointRadius) = Ellipse(circle.center, circle.ρ, circle.ρ;  thickness = circle.thickness, fill = circle.fill)
+Ellipse(x::Int, y::Int, args...; kwargs...) = Ellipse(Point(x,y), args...; kwargs...)
+Ellipse(p::CartesianIndex{2}, args...; kwargs...) = Ellipse(Point(p), args...; kwargs...)
+Ellipse(circle::CirclePointRadius) = Ellipse(circle.center, circle.ρ, circle.ρ; thickness = circle.thickness, fill = circle.fill)
 
 function draw!(img::AbstractArray{T, 2}, ellipse::Ellipse, color::T) where T<:Colorant
 	ys = Int[]

--- a/test/circle2d.jl
+++ b/test/circle2d.jl
@@ -42,8 +42,6 @@ using LinearAlgebra
 
         res = @inferred draw(img, CirclePointRadius(Point(6, 6), 5; thickness = 3, fill = false))
         @test all(expected .== res)
-
-        @test CirclePointRadius(Point(6, 6), 5, 3, false) == CirclePointRadius(Point(6, 6), 5; thickness = 3, fill = false)
         
         err = ArgumentError("Thickness 7 should be smaller than 5.")
         @test_throws err CirclePointRadius(CartesianIndex(6, 6), 5; thickness = 7, fill = false)

--- a/test/ellipse2d.jl
+++ b/test/ellipse2d.jl
@@ -52,9 +52,6 @@
                            0 0 0 1 1 1 1 1 0 0 ]
     res = @inferred draw(img, Ellipse(CirclePointRadius(Point(6, 6), 5; thickness = 4, fill = false)))
     @test all(expected .== res)
-
-
-    @test Ellipse(Point(6, 6), 5, 5, 3, false) == Ellipse(Point(6, 6), 5, 5; thickness = 3, fill = false)
         
     err = ArgumentError("Thickness 7 should be smaller than 5.")
     @test_throws err Ellipse(CartesianIndex(6, 6), 5, 5; thickness = 7, fill = false)


### PR DESCRIPTION
follow up #51

When things become complex, it will be a nightmare to fix the method
ambiguity with too many positional argument. Because keyword parameters
are not used in method dispatch, it is more friendly to both users and
maintainers.

This commit also fixes the incremental complilation issue; there are two
duplicated methods.

cc: @ashwani-rathee 