### PR TITLE
Add more examples for document

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,5 @@
 using Documenter, ImageDraw
 
-makedocs(sitename="Documentation",
+makedocs(sitename="ImageDraw.jl",
             format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"))
 deploydocs(repo = "github.com/JuliaImages/ImageDraw.jl.git")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,57 +20,70 @@ mkpath("images")
 ```
 
 ```@example usage
-using TestImages, ImageDraw, ColorVectorSpace
+using Images, TestImages, ImageDraw
 using FileIO # hide
 img = testimage("lighthouse")
 
-# Detect edges at different scales by adjusting the `spatial_scale` parameter.
 draw!(img, Ellipse(CirclePointRadius(350,200,100)))
-save("images/lighthouse_circle.png", img) # hide
+save("images/lighthouse_circle.png", img); nothing # hide
 ```
 
-When displayed, these three images look like this:
-```@raw html
-<img src="images/lighthouse_circle.png" width="512px" alt="edge detection demo 1 image" />
-<p>
-```
+![](images/lighthouse_circle.png)
 
 Drawing a circle with a thickness
 
 ```@example usage
-using TestImages, ImageDraw, ColorVectorSpace
-using FileIO # hide
 img = testimage("lighthouse")
 
 # With keyword argument fill = false, circle with given thickness is computed 
 draw!(img, Ellipse(CirclePointRadius(350, 200, 100; thickness = 75, fill = false)))
+save("images/lighthouse_circle_thickness.png", img); nothing # hide
 ```
+
+![](images/lighthouse_circle_thickness.png)
 
 Drawing a Rectangle.
 
 ```@example usage
-using TestImages, ImageDraw, ImageCore, ImageShow
-using FileIO # hide
 img = testimage("lighthouse")
 
 img_example_stage1 = draw!(img, Polygon(RectanglePoints(Point(10, 10), Point(100, 100))), RGB{N0f8}(1))
 img_example_stage2 = draw!(img_example_stage1, Polygon(RectanglePoints(CartesianIndex(110, 10), CartesianIndex(200, 200))), RGB{N0f8}(1))
 img_example_stage3 = draw!(img_example_stage2, Polygon(RectanglePoints(220, 10, 300, 300)), RGB{N0f8}(1))
+save("images/lighthouse_rectangle.png", img); nothing # hide
 ```
+
+![](images/lighthouse_rectangle.png)
 
 Drawing a Cross.
 
 ```@example usage
-using TestImages, ImageDraw, ColorVectorSpace, ImageCore
-using FileIO # hide
-img = testimage("lighthouse");
+img = testimage("lighthouse")
 
-draw!(img, Cross(Point(200,150), 50), RGB{N0f8}(1))
-
-save("images/lighthouse_cross.png", img) # hide
+draw!(img, Cross(Point(200,150), 50), RGB{N0f8}(0,1,0))
+save("images/lighthouse_cross.png", img); nothing # hide
 ```
 
-```@raw html
-<img src="images/lighthouse_cross.png" width="512px" alt="edge detection demo 1 image" />
-<p>
+![](images/lighthouse_cross.png)
+
+Drawing Lines Segment and Point.
+
+```@example usage
+img = testimage("lighthouse")
+
+p1 = Point(200,150)
+p2 = Point(300,100)
+p3 = Point(550,250)
+
+draw!(img, LineTwoPoints(p1,p2), RGB{N0f8}(1,0,0))
+draw!(img, LineSegment(p1,p2), RGB{N0f8}(0,0,1))
+draw!(img, LineTwoPoints(p1,p3), RGB{N0f8}(1,0,0))
+draw!(img, LineSegment(p2,p3), RGB{N0f8}(0,0,1))
+
+for p in (p1,p2,p3)
+    draw!(img, p, RGB{N0f8}(1))
+end
+save("images/lighthouse_linesegment.png", img); nothing # hide
 ```
+
+![](images/lighthouse_linesegment.png)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,4 +1,4 @@
-# ImageDraw.jl Documentation
+# ImageDraw.jl
 
 A drawing package for JuliaImages
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -74,7 +74,7 @@ with keyword arguments `thickness` and `fill` for drawing hollow circle
 
 # Examples
 ```
-using ImageDraw,TestImages,ImageView, ColorVectorSpace
+using ImageDraw, TestImages, ImageView, ColorVectorSpace
 img = testimage("lighthouse")
 
 draw!(img, Ellipse(CirclePointRadius(350,200,100))) 
@@ -118,7 +118,7 @@ struct Path <: Drawable
 end
 
 """
-    ellipse = Ellipse(center, ρx, ρy; thickness = 0,fill = false)
+    ellipse = Ellipse(center, ρx, ρy; thickness=0, fill=false)
 
 A `Drawable` ellipse with center `center` and parameters `ρx` and `ρy`
 with keyword arguments `thickness` and `fill` for drawing hollow ellipse
@@ -134,7 +134,7 @@ img = testimage("lighthouse")
 
 draw(img, Ellipse(5, 5, 5, 5), Gray{N0f8}(0.5))
 draw(img, Ellipse(CartesianIndex(5,5), 5, 3))
-draw(img, Ellipse(CirclePointRadius(Point(6, 6), 5; thickness = 4, fill = false)))
+draw(img, Ellipse(CirclePointRadius(Point(6, 6), 5; thickness=4, fill=false)))
 ```
 """
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -340,6 +340,7 @@ Draws a single point after checkbounds() for coordinate in the image.
 Color Defaults to oneunit(T)
 
 """
+drawifinbounds!
 
 drawifinbounds!(img::AbstractArray{T,2}, p::Point, color::T = oneunit(T)) where {T<:Colorant} = drawifinbounds!(img, p.y, p.x, color)
 drawifinbounds!(img::AbstractArray{T,2}, p::CartesianIndex{2}, color::T = oneunit(T)) where {T<:Colorant} = drawifinbounds!(img, Point(p), color)

--- a/src/ellipse2d.jl
+++ b/src/ellipse2d.jl
@@ -22,8 +22,8 @@ function draw!(img::AbstractArray{T, 2}, ellipse::Ellipse, color::T) where T<:Co
 	end
 	for (yi, xi) in zip(ys, xs)
 		drawifinbounds!(img, yi, xi, color)
-		drawifinbounds!(img,2 * ellipse.center.y - yi, xi, color)
-		drawifinbounds!(img,yi, 2 * ellipse.center.x - xi, color)
+		drawifinbounds!(img, 2 * ellipse.center.y - yi, xi, color)
+		drawifinbounds!(img, yi, 2 * ellipse.center.x - xi, color)
 		drawifinbounds!(img, 2 * ellipse.center.y - yi, 2 * ellipse.center.x - xi, color)
 	end
 	img


### PR DESCRIPTION
This PR includes the following updates:
* Fix misleading words
* Update the title of the document
* Fix `@example` blocks in the document
* Fix docstring for `drawifinbounds!`