### PR TITLE
remove lines between docstring and symbol

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -210,7 +210,6 @@ verts = [CartesianIndex(2, 2), CartesianIndex(2, 6), CartesianIndex(6, 6), Carte
 fill_method = draw(img, verts, BoundaryFill(4, 4; fill_value = RGB(1), boundary_value = RGB(1)); closed = true)
 ```
 """
-
 struct BoundaryFill{T<:Colorant} <: AbstractPolyFillAlgorithm
     x::Int
     y::Int

--- a/src/polygonfill2d.jl
+++ b/src/polygonfill2d.jl
@@ -3,7 +3,6 @@
     (f::BoundaryFill)(res::AbstractArray{T,2}, verts::Vector{CartesianIndex{2}}, x::Int, y::Int, fill_value::T, boundary_value::T) where {T <: Colorant}
 
 """
-
 function (f::BoundaryFill)(
     res::AbstractArray{T,2},
     verts::Vector{CartesianIndex{2}},
@@ -47,7 +46,6 @@ verts = [CartesianIndex(2, 2), CartesianIndex(2, 6), CartesianIndex(6, 6), Carte
 draw!(img, verts, BoundaryFill(4, 4; fill_value = RGB(1), boundary_value = RGB(1)); closed = true)
 ```
 """
-
 function draw!(
     img::AbstractArray{<:Colorant,N},
     verts::Vector{CartesianIndex{N}},


### PR DESCRIPTION
Empty lines are not allowed; otherwise `?BoundaryFill` gives nothing useful:

```julia
help?> BoundaryFill
search: BoundaryFill

  No documentation found.

  ImageDraw.BoundaryFill is of type UnionAll.

  Summary
  ≡≡≡≡≡≡≡≡≡

  struct UnionAll <: Type{T}

  Fields
  ≡≡≡≡≡≡≡≡

  var  :: TypeVar
  body :: Any

  Supertype Hierarchy
  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

  UnionAll <: Type{T} <: Any
```

This PR fixes the docstring issue by removing those unnecessary empty lines.

cc: @ashwani-rathee 