### PR TITLE
Filled Polygon Option 

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -153,10 +153,11 @@ end
 Ellipse(center::Point, ρx::T, ρy::U; kwargs...) where {T<:Real, U<:Real} = Ellipse{T,U}(center, ρx, ρy; kwargs...)
 
 """ 
-    polygon = Polygon([vertex])
+    polygon = Polygon([vertex]; fill=false)
 
 A `Drawable` polygon i.e. a closed path created by joining the
 consecutive points in `[vertex]` along with the first and last point.
+The keyword argument `fill` allows to draw filled areas enclosed by the closed path.
 !!! note
     This will create a closed path. For a non-closed path, see `Path`
 """

--- a/src/core.jl
+++ b/src/core.jl
@@ -162,6 +162,9 @@ consecutive points in `[vertex]` along with the first and last point.
 """
 struct Polygon <: Drawable
     vertices::Vector{Point}
+    fill::Bool
+
+    Polygon(vertices::Vector{Point}; fill::Bool = false) = new(vertices, fill)
 end
 
 """

--- a/src/paths.jl
+++ b/src/paths.jl
@@ -33,7 +33,7 @@ function polygonscanfill!(img::AbstractArray{T, 2}, polygon::Polygon, color::T) 
     vertices = polygon.vertices
 
     vertices_y = map((v) -> v.y, vertices)
-    scan_range = range(clamp.((floor(Int, minimum(vertices_y)), ceil(Int, maximum(vertices_y))), first(image_height_indices), last(image_height_indices))...)
+    scan_range = range(clamp.((floor(Int, minimum(vertices_y)), ceil(Int, maximum(vertices_y))), first(image_height_indices), last(image_height_indices))..., step = 1)
 
     vertices_shifted = push!(vertices[2:length(vertices)], vertices[1])
     intersections_x = Vector{Int}()

--- a/src/paths.jl
+++ b/src/paths.jl
@@ -33,7 +33,7 @@ function polygonscanfill!(img::AbstractArray{T, 2}, polygon::Polygon, color::T) 
     vertices = polygon.vertices
 
     vertices_y = map((v) -> v.y, vertices)
-    scan_range = max(floor(Int, minimum(vertices_y)), 1):min(ceil(Int, maximum(vertices_y)), image_height)
+    scan_range = clamp(floor(Int, minimum(vertices_y)), 1, image_height):clamp(ceil(Int, maximum(vertices_y)), 1, image_height)
 
     vertices_shifted = push!(vertices[begin + 1:end], vertices[begin])
     intersections_x = Vector{Int}()
@@ -48,8 +48,12 @@ function polygonscanfill!(img::AbstractArray{T, 2}, polygon::Polygon, color::T) 
         sort!(intersections_x)
 
         for i in 1:2:length(intersections_x)
-            if checkbounds(Bool, img, y, intersections_x[i]) || checkbounds(Bool, img, y, intersections_x[i + 1])
-                img[y, max(intersections_x[i], 1):min(intersections_x[i + 1], image_width)] .= color
+            x1, x2 = intersections_x[i], intersections_x[i + 1]
+
+            if !(x2 < 1 || x1 > image_width)
+                x1, x2 = clamp(x1, 1, image_width), clamp(x2, 1, image_width)
+
+                img[y, x1:x2] .= color
             end
         end
 

--- a/src/paths.jl
+++ b/src/paths.jl
@@ -33,12 +33,12 @@ function polygonscanfill!(img::AbstractArray{T, 2}, polygon::Polygon, color::T) 
     vertices = polygon.vertices
 
     vertices_y = map((v) -> v.y, vertices)
-    scan_range = (max(floor(Int, minimum(vertices_y)), 1), min(ceil(Int, maximum(vertices_y)), image_height))
+    scan_range = max(floor(Int, minimum(vertices_y)), 1):min(ceil(Int, maximum(vertices_y)), image_height)
 
     vertices_shifted = push!(vertices[begin + 1:end], vertices[begin])
     intersections_x = Vector{Int}()
 
-    for y in scan_range[1]:scan_range[2]
+    for y in scan_range
         for (vertex_a, vertex_b) in zip(vertices, vertices_shifted)
             if vertex_a.y < y && vertex_b.y >= y || vertex_b.y < y && vertex_a.y >= y
                 push!(intersections_x, round(Int, vertex_a.x + (y - vertex_a.y) / (vertex_b.y - vertex_a.y) * (vertex_b.x - vertex_a.x)))

--- a/src/paths.jl
+++ b/src/paths.jl
@@ -29,11 +29,11 @@ function draw!(img::AbstractArray{T, 2}, polygon::Polygon, color::T) where T<:Co
 end
 
 function polygonscanfill!(img::AbstractArray{T, 2}, polygon::Polygon, color::T) where T <: Colorant
-    image_height, image_width = size(img)
+    image_height_indices, image_width_indices = axes(img)
     vertices = polygon.vertices
 
     vertices_y = map((v) -> v.y, vertices)
-    scan_range = clamp(floor(Int, minimum(vertices_y)), 1, image_height):clamp(ceil(Int, maximum(vertices_y)), 1, image_height)
+    scan_range = range(clamp.((floor(Int, minimum(vertices_y)), ceil(Int, maximum(vertices_y))), first(image_height_indices), last(image_height_indices))...)
 
     vertices_shifted = push!(vertices[2:length(vertices)], vertices[1])
     intersections_x = Vector{Int}()
@@ -50,8 +50,8 @@ function polygonscanfill!(img::AbstractArray{T, 2}, polygon::Polygon, color::T) 
         for i in 1:2:length(intersections_x)
             x1, x2 = intersections_x[i], intersections_x[i + 1]
 
-            if !(x2 < 1 || x1 > image_width)
-                x1, x2 = clamp(x1, 1, image_width), clamp(x2, 1, image_width)
+            if !(x2 < first(image_width_indices) || x1 > last(image_width_indices))
+                x1, x2 = clamp.((x1, x2), first(image_width_indices), last(image_width_indices))
 
                 img[y, x1:x2] .= color
             end

--- a/src/paths.jl
+++ b/src/paths.jl
@@ -35,7 +35,7 @@ function polygonscanfill!(img::AbstractArray{T, 2}, polygon::Polygon, color::T) 
     vertices_y = map((v) -> v.y, vertices)
     scan_range = clamp(floor(Int, minimum(vertices_y)), 1, image_height):clamp(ceil(Int, maximum(vertices_y)), 1, image_height)
 
-    vertices_shifted = push!(vertices[begin + 1:end], vertices[begin])
+    vertices_shifted = push!(vertices[2:length(vertices)], vertices[1])
     intersections_x = Vector{Int}()
 
     for y in scan_range

--- a/test/paths.jl
+++ b/test/paths.jl
@@ -39,6 +39,20 @@ using Test
     @test all(x->x==true, img[3,1:3])==true
     @test all(x->x==false, img[2,2:3])==true
     @test img[2,4]==true
+
+    # filled polygon
+    img = @inferred draw(zeros(Gray{Bool},5,5), Polygon(poly_tuples; fill = true))
+    @test all(x->x==true, img[1,:])==true
+    @test all(x->x==true, img[2,1:4])==true
+    @test all(x->x==true, img[3,1:3])==true
+
+    poly_tuples = [(1,1),(5,5),(5,1),(1,5)]
+    img = @inferred draw(zeros(Gray{Bool},5,5), Polygon(poly_tuples; fill = true))
+    @test all(x->x==true, img[:,1])==true
+    @test all(x->x==true, img[2:4,2])==true
+    @test img[3, 3]==true
+    @test all(x->x==true, img[2:4,4])==true
+    @test all(x->x==true, img[:,5])==true
 end
 
 @testset "Path" begin

--- a/test/paths.jl
+++ b/test/paths.jl
@@ -46,6 +46,10 @@ using Test
     @test all(x->x==true, img[2,1:4])==true
     @test all(x->x==true, img[3,1:3])==true
 
+    @test img[2,5]==false
+    @test all(x->x==false, img[3,4:5])==true
+    @test all(x->x==false, img[4:5,:])==true
+
     poly_tuples = [(1,1),(5,5),(5,1),(1,5)]
     img = @inferred draw(zeros(Gray{Bool},5,5), Polygon(poly_tuples; fill = true))
     @test all(x->x==true, img[:,1])==true
@@ -53,11 +57,18 @@ using Test
     @test img[3, 3]==true
     @test all(x->x==true, img[2:4,4])==true
     @test all(x->x==true, img[:,5])==true
+    
+    @test all(x->x==false, img[1,2:4])==true
+    @test all(x->x==false, (img[2,3], img[4,3]))==true
+    @test all(x->x==false, img[5,2:4])==true
 
     poly_tuples_outside_image = [(-1, 2), (3, 6), (7, 2)]
     img = @inferred draw(zeros(Gray{Bool},5,5), Polygon(poly_tuples_outside_image; fill = true))
-    @test all(x->x==true, img[2:3,:])==true
+    @test all(x->x==true, img[2:4,:])==true
     @test all(x->x==true, img[5,2:3])==true
+
+    @test all(x->x==false, img[1,:])==true
+    @test all(x->x==false, (img[5,1], img[5,5]))==true
 end
 
 @testset "Path" begin

--- a/test/paths.jl
+++ b/test/paths.jl
@@ -53,6 +53,11 @@ using Test
     @test img[3, 3]==true
     @test all(x->x==true, img[2:4,4])==true
     @test all(x->x==true, img[:,5])==true
+
+    poly_tuples_outside_image = [(-1, 2), (3, 6), (7, 2)]
+    img = @inferred draw(zeros(Gray{Bool},5,5), Polygon(poly_tuples_outside_image; fill = true))
+    @test all(x->x==true, img[2:3,:])==true
+    @test all(x->x==true, img[5,2:3])==true
 end
 
 @testset "Path" begin


### PR DESCRIPTION
- added simple fill option for polygons, similar to the filled ellipse
- the polygon's boundary must be drawn even in the filled case, as the scanline filling algorithm cannot handle multiple vertices on a straight line