### PR TITLE
Improve on docstring for Point

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -16,7 +16,9 @@ abstract type AbstractPolyFillAlgorithm end
     p = Point(x,y)
     p = Point(c)
 
-A `Drawable` point on the image
+A `Drawable` point on the image. 
+
+Note that while the `x` and `y` in `Point(x,y)` stand to mean the `x` and `y` pixel-distances from the left-top corner of the image respectively, the first and second elements in a CartesianIndex (i.e. `Point(c)`) will mean the opposite (`y` and `x` distances respectively).
 """
 struct Point <: Drawable
     x::Int


### PR DESCRIPTION
This clarifies the ambiguity of the order of `x` and `y` versus `i` and `j` in a `Point` called with a coordinate versus a Cartesian index. Not huge, I admit, but might clarify things in the future.