### PR TITLE
fix #78

### DIFF
--- a/src/ellipse2d.jl
+++ b/src/ellipse2d.jl
@@ -5,8 +5,6 @@ Ellipse(p::CartesianIndex{2}, args...; kwargs...) = Ellipse(Point(p), args...; k
 Ellipse(circle::CirclePointRadius) = Ellipse(circle.center, circle.ρ, circle.ρ; thickness = circle.thickness, fill = circle.fill)
 
 function draw!(img::AbstractArray{T, 2}, ellipse::Ellipse, color::T) where T<:Colorant
-	ys = Int[]
-	xs = Int[]
 	break_point = 0
 	if ellipse.fill == false
 		break_point = ((ellipse.ρy - ellipse.thickness) / ellipse.ρy) ^ 2 + ((ellipse.ρx - ellipse.thickness) / ellipse.ρx) ^ 2 
@@ -15,16 +13,14 @@ function draw!(img::AbstractArray{T, 2}, ellipse::Ellipse, color::T) where T<:Co
 		for j in ellipse.center.x : ellipse.center.x + ellipse.ρx
 			val = ((i - ellipse.center.y) / ellipse.ρy) ^ 2 + ((j - ellipse.center.x) / ellipse.ρx) ^ 2
 			if val < 1 && val >= break_point			
-				push!(ys, i)
-				push!(xs, j)
+        yi = Int(i)
+        xi = Int(j)
+        drawifinbounds!(img, yi, xi, color)
+        drawifinbounds!(img, 2 * ellipse.center.y - yi, xi, color)
+        drawifinbounds!(img, yi, 2 * ellipse.center.x - xi, color)
+        drawifinbounds!(img, 2 * ellipse.center.y - yi, 2 * ellipse.center.x - xi, color)
 			end
 		end
-	end
-	for (yi, xi) in zip(ys, xs)
-		drawifinbounds!(img, yi, xi, color)
-		drawifinbounds!(img, 2 * ellipse.center.y - yi, xi, color)
-		drawifinbounds!(img, yi, 2 * ellipse.center.x - xi, color)
-		drawifinbounds!(img, 2 * ellipse.center.y - yi, 2 * ellipse.center.x - xi, color)
 	end
 	img
 end

--- a/src/ellipse2d.jl
+++ b/src/ellipse2d.jl
@@ -5,22 +5,22 @@ Ellipse(p::CartesianIndex{2}, args...; kwargs...) = Ellipse(Point(p), args...; k
 Ellipse(circle::CirclePointRadius) = Ellipse(circle.center, circle.ρ, circle.ρ; thickness = circle.thickness, fill = circle.fill)
 
 function draw!(img::AbstractArray{T, 2}, ellipse::Ellipse, color::T) where T<:Colorant
-  break_point = 0
-  if ellipse.fill == false
-    break_point = ((ellipse.ρy - ellipse.thickness) / ellipse.ρy) ^ 2 + ((ellipse.ρx - ellipse.thickness) / ellipse.ρx) ^ 2 
-  end
-  for i in ellipse.center.y : ellipse.center.y + ellipse.ρy
-    for j in ellipse.center.x : ellipse.center.x + ellipse.ρx
-      val = ((i - ellipse.center.y) / ellipse.ρy) ^ 2 + ((j - ellipse.center.x) / ellipse.ρx) ^ 2
-      if val < 1 && val >= break_point      
-        yi = Int(i)
-        xi = Int(j)
-        drawifinbounds!(img, yi, xi, color)
-        drawifinbounds!(img, 2 * ellipse.center.y - yi, xi, color)
-        drawifinbounds!(img, yi, 2 * ellipse.center.x - xi, color)
-        drawifinbounds!(img, 2 * ellipse.center.y - yi, 2 * ellipse.center.x - xi, color)
-      end
+    break_point = 0
+    if ellipse.fill == false
+        break_point = ((ellipse.ρy - ellipse.thickness) / ellipse.ρy) ^ 2 + ((ellipse.ρx - ellipse.thickness) / ellipse.ρx) ^ 2 
     end
-  end
-  img
+    for i in ellipse.center.y : ellipse.center.y + ellipse.ρy
+        for j in ellipse.center.x : ellipse.center.x + ellipse.ρx
+            val = ((i - ellipse.center.y) / ellipse.ρy) ^ 2 + ((j - ellipse.center.x) / ellipse.ρx) ^ 2
+            if val < 1 && val >= break_point      
+                yi = Int(i)
+                xi = Int(j)
+                drawifinbounds!(img, yi, xi, color)
+                drawifinbounds!(img, 2 * ellipse.center.y - yi, xi, color)
+                drawifinbounds!(img, yi, 2 * ellipse.center.x - xi, color)
+                drawifinbounds!(img, 2 * ellipse.center.y - yi, 2 * ellipse.center.x - xi, color)
+            end
+        end
+    end
+    img
 end

--- a/src/ellipse2d.jl
+++ b/src/ellipse2d.jl
@@ -5,22 +5,22 @@ Ellipse(p::CartesianIndex{2}, args...; kwargs...) = Ellipse(Point(p), args...; k
 Ellipse(circle::CirclePointRadius) = Ellipse(circle.center, circle.ρ, circle.ρ; thickness = circle.thickness, fill = circle.fill)
 
 function draw!(img::AbstractArray{T, 2}, ellipse::Ellipse, color::T) where T<:Colorant
-	break_point = 0
-	if ellipse.fill == false
-		break_point = ((ellipse.ρy - ellipse.thickness) / ellipse.ρy) ^ 2 + ((ellipse.ρx - ellipse.thickness) / ellipse.ρx) ^ 2 
-	end
-	for i in ellipse.center.y : ellipse.center.y + ellipse.ρy
-		for j in ellipse.center.x : ellipse.center.x + ellipse.ρx
-			val = ((i - ellipse.center.y) / ellipse.ρy) ^ 2 + ((j - ellipse.center.x) / ellipse.ρx) ^ 2
-			if val < 1 && val >= break_point			
+  break_point = 0
+  if ellipse.fill == false
+    break_point = ((ellipse.ρy - ellipse.thickness) / ellipse.ρy) ^ 2 + ((ellipse.ρx - ellipse.thickness) / ellipse.ρx) ^ 2 
+  end
+  for i in ellipse.center.y : ellipse.center.y + ellipse.ρy
+    for j in ellipse.center.x : ellipse.center.x + ellipse.ρx
+      val = ((i - ellipse.center.y) / ellipse.ρy) ^ 2 + ((j - ellipse.center.x) / ellipse.ρx) ^ 2
+      if val < 1 && val >= break_point      
         yi = Int(i)
         xi = Int(j)
         drawifinbounds!(img, yi, xi, color)
         drawifinbounds!(img, 2 * ellipse.center.y - yi, xi, color)
         drawifinbounds!(img, yi, 2 * ellipse.center.x - xi, color)
         drawifinbounds!(img, 2 * ellipse.center.y - yi, 2 * ellipse.center.x - xi, color)
-			end
-		end
-	end
-	img
+      end
+    end
+  end
+  img
 end


### PR DESCRIPTION
This PR drammatically improves on performance for ellipse drawing:

```julia
using Revise
using BenchmarkTools
using ImageDraw 
import ColorTypes: RGB, N0f8

img = rand(RGB{N0f8}, 1000, 1000)
c = CirclePointRadius(Point(500, 500), 400)
f() = draw!(img, c)
@benchmark f()
```
before this PR:
```julia
BenchmarkTools.Trial: 1875 samples with 1 evaluation.
 Range (min … max):  2.258 ms …   5.262 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.499 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.600 ms ± 292.306 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

       ▅██▆▂▁                                                  
  ▂▃▄▇▇███████▆▇▅▆▇██▆▅▄▃▃▃▃▃▃▃▂▂▁▂▂▂▂▂▃▃▃▃▃▃▃▂▂▂▂▂▃▃▂▂▂▂▁▁▂▂ ▃
  2.26 ms         Histogram: frequency by time        3.63 ms <

 Memory estimate: 3.66 MiB, allocs estimate: 22.
```
After this PR:
```julia
BenchmarkTools.Trial: 8135 samples with 1 evaluation.
 Range (min … max):  594.081 μs …  1.619 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     609.660 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   612.257 μs ± 26.233 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

               █        ▁                                       
  ▂▂▂▂▁▁▂▂▃▃▂▃▃█▄▄▄▇▆▅▅▄█▄▄▄▄▄▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  594 μs          Histogram: frequency by time          643 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
````